### PR TITLE
feat: Add PR preview deployments to staging environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,14 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
   deployments: write
+  pull-requests: write
 
 jobs:
   build-deploy:
@@ -33,6 +37,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to Cloudflare Pages
+        id: deploy
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -40,3 +45,48 @@ jobs:
           projectName: akashic
           directory: dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment PR with preview URL
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deploymentUrl = '${{ steps.deploy.outputs.url }}';
+            const body = `## 🚀 Staging Deployment Ready!
+
+            Your PR has been deployed to a staging environment for testing.
+
+            **Preview URL:** ${deploymentUrl}
+
+            This staging environment uses the same database and authentication as production, so you can test with real data.
+
+            ---
+            <sub>Deployed via Cloudflare Pages</sub>`;
+
+            // Find existing comment to update
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Staging Deployment Ready')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }


### PR DESCRIPTION
- Deploy to Cloudflare Pages on pull requests to main branch
- Auto-comment on PRs with the staging preview URL
- Preview uses same database and auth as production for design testing
- Comment updates on subsequent pushes instead of creating duplicates