### PR TITLE
feat: Add iOS-like drag gestures for mobile panel

### DIFF
--- a/src/components/trek/InfoPanel.tsx
+++ b/src/components/trek/InfoPanel.tsx
@@ -70,8 +70,10 @@ export const InfoPanel = memo(function InfoPanel({
         currentSnapIndex,
         onSnapChange: handleSnapChange,
         panelRef,
+        onDismiss: onBack, // Swipe down from minimized to go back to globe
         velocityThreshold: 0.4,
         distanceThreshold: 40,
+        dismissThreshold: 80, // 80px to dismiss
     });
 
     // Panel height based on state (only used for initial render and non-drag state)
@@ -196,16 +198,23 @@ export const InfoPanel = memo(function InfoPanel({
                 </div>
             )}
 
-            {/* Header */}
-            <div style={{
-                padding: isMobile ? `8px ${padding}px 16px` : `${padding}px`,
-                borderBottom: panelState !== 'minimized' ? `1px solid ${colors.glass.borderSubtle}` : 'none',
-                display: 'flex',
-                flexDirection: isMobile ? 'row' : 'column',
-                alignItems: isMobile ? 'center' : 'stretch',
-                justifyContent: isMobile ? 'space-between' : 'flex-start',
-                flexShrink: 0
-            }}>
+            {/* Header - also draggable on mobile for larger touch target */}
+            <div
+                onTouchStart={isMobile ? dragHandlers.onTouchStart : undefined}
+                onTouchMove={isMobile ? dragHandlers.onTouchMove : undefined}
+                onTouchEnd={isMobile ? dragHandlers.onTouchEnd : undefined}
+                style={{
+                    padding: isMobile ? `8px ${padding}px 16px` : `${padding}px`,
+                    borderBottom: panelState !== 'minimized' ? `1px solid ${colors.glass.borderSubtle}` : 'none',
+                    display: 'flex',
+                    flexDirection: isMobile ? 'row' : 'column',
+                    alignItems: isMobile ? 'center' : 'stretch',
+                    justifyContent: isMobile ? 'space-between' : 'flex-start',
+                    flexShrink: 0,
+                    touchAction: isMobile ? 'none' : 'auto',
+                    cursor: isMobile ? (dragState.isDragging ? 'grabbing' : 'grab') : 'default',
+                }}
+            >
                 {!isMobile && (
                     <GlassButton
                         variant="ghost"


### PR DESCRIPTION
## Summary
- Create new `useDragGesture` hook with velocity-based snap decisions
- Panel follows finger during drag using `translateY` transform
- Smooth spring animation on release (iOS-like cubic-bezier curve)
- Visual feedback on drag handle during interaction

## Changes
- **New hook**: `src/hooks/useDragGesture.ts` - iOS-like drag gesture with velocity detection and rubber-banding
- **Updated**: `src/components/trek/InfoPanel.tsx` - Use new drag gesture for mobile bottom sheet

## Test plan
- [ ] Test on iPhone: swipe up/down on the panel drag handle
- [ ] Verify panel follows finger during drag (no delay)
- [ ] Fast swipe should snap based on velocity direction
- [ ] Slow drag past threshold should snap to nearest point
- [ ] Release should animate smoothly with spring physics

🤖 Generated with [Claude Code](https://claude.com/claude-code)