### PR TITLE
fix: Auto-recenter globe when zooming back out after pan/zoom

### DIFF
--- a/e2e/globe-centering.spec.ts
+++ b/e2e/globe-centering.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Tests for globe centering behavior after zoom/pan operations.
+ *
+ * Issue: Zooming in, moving around, and then zooming back out
+ * can cause the globe position to shift so it's no longer centered.
+ *
+ * Fix: The useMapbox hook now includes a zoomend listener that automatically
+ * recenters the globe when the user zooms back out to globe level (zoom < 2.5)
+ * while in globe view mode with no trek selected.
+ */
+test.describe('Globe Zoom Centering', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+        // Wait for map canvas to be ready
+        await page.waitForSelector('canvas', { timeout: 30000 });
+        // Wait for map to fully initialize and settle
+        await page.waitForTimeout(2000);
+    });
+
+    /**
+     * Helper to simulate scroll wheel zoom on the map canvas
+     */
+    async function scrollZoom(page: Page, deltaY: number, times: number = 1): Promise<void> {
+        const canvas = page.locator('canvas');
+        const box = await canvas.boundingBox();
+        if (!box) throw new Error('Canvas not found');
+
+        const centerX = box.x + box.width / 2;
+        const centerY = box.y + box.height / 2;
+
+        await page.mouse.move(centerX, centerY);
+
+        for (let i = 0; i < times; i++) {
+            await page.mouse.wheel(0, deltaY);
+            await page.waitForTimeout(100);
+        }
+    }
+
+    /**
+     * Helper to simulate drag/pan on the map
+     */
+    async function panMap(page: Page, offsetX: number, offsetY: number): Promise<void> {
+        const canvas = page.locator('canvas');
+        const box = await canvas.boundingBox();
+        if (!box) throw new Error('Canvas not found');
+
+        const startX = box.x + box.width / 2;
+        const startY = box.y + box.height / 2;
+
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+        await page.mouse.move(startX + offsetX, startY + offsetY, { steps: 10 });
+        await page.mouse.up();
+        await page.waitForTimeout(300);
+    }
+
+    test('globe returns to center after zoom in, pan, and zoom out', async ({ page }) => {
+        // Wait for globe rotation to start (indicates globe is ready)
+        await page.waitForTimeout(4000);
+
+        // Stop rotation by clicking the map
+        const canvas = page.locator('canvas');
+        await canvas.click();
+        await page.waitForTimeout(500);
+
+        // STEP 1: Zoom in significantly
+        await scrollZoom(page, -200, 5); // Negative = zoom in
+        await page.waitForTimeout(1000);
+
+        // STEP 2: Pan the map in various directions to move away from center
+        await panMap(page, 150, 0);   // Pan right
+        await panMap(page, 0, -100);  // Pan up
+        await panMap(page, -100, 50); // Pan left-down
+        await page.waitForTimeout(500);
+
+        // STEP 3: Zoom back out to globe view
+        await scrollZoom(page, 200, 8); // Positive = zoom out
+        await page.waitForTimeout(2500); // Wait for auto-recenter animation
+
+        // The globe should now be properly centered (auto-recenter triggered)
+        await expect(page).toHaveScreenshot('globe-centered-after-zoom.png', {
+            maxDiffPixelRatio: 0.15,
+            threshold: 0.3
+        });
+    });
+
+    test('globe center position is stable after multiple zoom/pan cycles', async ({ page }) => {
+        // Wait for initial load and rotation
+        await page.waitForTimeout(4000);
+
+        // Stop rotation
+        const canvas = page.locator('canvas');
+        await canvas.click();
+        await page.waitForTimeout(500);
+
+        // Perform multiple zoom/pan cycles
+        for (let cycle = 0; cycle < 3; cycle++) {
+            // Zoom in
+            await scrollZoom(page, -150, 4);
+            await page.waitForTimeout(500);
+
+            // Pan movements
+            await panMap(page, (cycle + 1) * 50, -(cycle + 1) * 30);
+            await panMap(page, -(cycle + 1) * 30, (cycle + 1) * 40);
+            await page.waitForTimeout(300);
+
+            // Zoom back out
+            await scrollZoom(page, 150, 6);
+            await page.waitForTimeout(2000); // Wait for auto-recenter
+        }
+
+        // After all cycles, the globe should still be centered
+        await expect(page).toHaveScreenshot('globe-after-multi-cycles.png', {
+            maxDiffPixelRatio: 0.2,
+            threshold: 0.3
+        });
+    });
+
+    test('clicking title recenters globe after pan/zoom', async ({ page }) => {
+        // Wait for initial load
+        await page.waitForTimeout(3000);
+
+        // Stop rotation
+        const canvas = page.locator('canvas');
+        await canvas.click();
+        await page.waitForTimeout(500);
+
+        // Zoom in and pan to disrupt centering
+        await scrollZoom(page, -200, 5);
+        await page.waitForTimeout(500);
+        await panMap(page, 200, -100);
+        await page.waitForTimeout(500);
+
+        // Zoom back out (auto-recenter should trigger)
+        await scrollZoom(page, 200, 6);
+        await page.waitForTimeout(2000);
+
+        // Click the Akashic title to explicitly trigger flyToGlobe
+        await page.getByText('Akashic').click();
+        await page.waitForTimeout(3500); // Wait for flyToGlobe animation
+
+        // The globe should be properly centered
+        await expect(page).toHaveScreenshot('globe-recentered-via-title.png', {
+            maxDiffPixelRatio: 0.15,
+            threshold: 0.3
+        });
+    });
+});

--- a/src/hooks/useMapbox.ts
+++ b/src/hooks/useMapbox.ts
@@ -63,6 +63,13 @@ export function useMapbox({ containerRef, onTrekSelect, onPhotoClick, onRouteCli
     const selectedTrekRef = useRef<string | null>(null);
     const playbackAnimationRef = useRef<number | null>(null);
     const playbackCallbackRef = useRef<((camp: Camp) => void) | null>(null);
+    // Track if we're in globe view mode (for auto-recentering)
+    const isGlobeViewRef = useRef<boolean>(true);
+    // Track if we should skip the next recenter (to avoid conflicts with flyToGlobe)
+    const skipRecenterRef = useRef<boolean>(false);
+    // Expected globe center coordinates
+    const GLOBE_CENTER: [number, number] = [30, 15];
+    const GLOBE_ZOOM_THRESHOLD = 2.5; // Zoom level below which we consider it "globe view"
     const [mapReady, setMapReady] = useState(false);
     const [dataLayersReady, setDataLayersReady] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -447,6 +454,70 @@ export function useMapbox({ containerRef, onTrekSelect, onPhotoClick, onRouteCli
         };
     }, [containerRef]);
 
+    // Auto-recenter globe when zooming back out to globe level
+    // This fixes the issue where zooming in, panning, and zooming out causes the globe to be off-center
+    useEffect(() => {
+        const map = mapRef.current;
+        if (!map || !mapReady) return;
+
+        let isUserZooming = false;
+        let lastUserZoom = map.getZoom();
+
+        const onZoomStart = () => {
+            isUserZooming = true;
+            lastUserZoom = map.getZoom();
+        };
+
+        const onZoomEnd = () => {
+            if (!mapRef.current || !isUserZooming) return;
+
+            const currentZoom = mapRef.current.getZoom();
+            const wasZoomingOut = currentZoom < lastUserZoom;
+            isUserZooming = false;
+
+            // Only recenter if:
+            // 1. We're in globe view mode (not viewing a trek)
+            // 2. No trek is selected
+            // 3. We zoomed OUT (not in)
+            // 4. We're now at or below the globe zoom threshold
+            // 5. We're not skipping recenter (e.g., flyToGlobe is handling it)
+            if (
+                isGlobeViewRef.current &&
+                !selectedTrekRef.current &&
+                wasZoomingOut &&
+                currentZoom <= GLOBE_ZOOM_THRESHOLD &&
+                !skipRecenterRef.current
+            ) {
+                const center = mapRef.current.getCenter();
+                const distanceFromCenter = Math.sqrt(
+                    Math.pow(center.lng - GLOBE_CENTER[0], 2) +
+                    Math.pow(center.lat - GLOBE_CENTER[1], 2)
+                );
+
+                // Only recenter if we've drifted more than 5 degrees from center
+                if (distanceFromCenter > 5) {
+                    const isMobile = window.matchMedia('(max-width: 768px)').matches;
+                    mapRef.current.easeTo({
+                        center: GLOBE_CENTER,
+                        zoom: isMobile ? 1.2 : 1.5,
+                        pitch: 0,
+                        bearing: 0,
+                        duration: 1500,
+                        easing: (t) => 1 - Math.pow(1 - t, 3) // ease-out cubic
+                    });
+                }
+            }
+        };
+
+        map.on('zoomstart', onZoomStart);
+        map.on('zoomend', onZoomEnd);
+
+        return () => {
+            map.off('zoomstart', onZoomStart);
+            map.off('zoomend', onZoomEnd);
+        };
+    }, [mapReady]);
+
     // Add trek markers and routes when data is available
     useEffect(() => {
         const map = mapRef.current;
@@ -598,6 +669,11 @@ export function useMapbox({ containerRef, onTrekSelect, onPhotoClick, onRouteCli
         const map = mapRef.current;
         if (!map || !mapReady) return;
 
+        // Mark that we're in globe view mode
+        isGlobeViewRef.current = true;
+        // Skip the next auto-recenter since flyToGlobe handles centering
+        skipRecenterRef.current = true;
+
         // Set globe atmosphere - transparent space so CSS starfield shows through
         map.setFog({
             'range': [1, 12],
@@ -625,6 +701,8 @@ export function useMapbox({ containerRef, onTrekSelect, onPhotoClick, onRouteCli
         const isMobile = window.matchMedia('(max-width: 768px)').matches;
 
         if (selectedTrek) {
+            // When focused on a trek at globe level, use trek position
+            selectedTrekRef.current = selectedTrek.id;
             map.flyTo({
                 center: [selectedTrek.lng, selectedTrek.lat],
                 zoom: isMobile ? 3 : 3.5,
@@ -636,8 +714,10 @@ export function useMapbox({ containerRef, onTrekSelect, onPhotoClick, onRouteCli
                 easing: (t) => 1 - Math.pow(1 - t, 3) // ease-out cubic
             });
         } else {
+            // No trek selected - fly to default globe center
+            selectedTrekRef.current = null;
             map.flyTo({
-                center: [30, 15],
+                center: GLOBE_CENTER,
                 zoom: isMobile ? 1.2 : 1.5,
                 pitch: 0,
                 bearing: 0,
@@ -647,6 +727,11 @@ export function useMapbox({ containerRef, onTrekSelect, onPhotoClick, onRouteCli
                 easing: (t) => 1 - Math.pow(1 - t, 3)
             });
         }
+
+        // Reset skip flag after animation completes
+        setTimeout(() => {
+            skipRecenterRef.current = false;
+        }, 3500);
     }, [mapReady]);
 
     // Highlight trek segment (defined before flyToTrek which uses it)
@@ -685,6 +770,10 @@ export function useMapbox({ containerRef, onTrekSelect, onPhotoClick, onRouteCli
     const flyToTrek = useCallback((selectedTrek: TrekConfig, selectedCamp: Camp | null = null) => {
         const map = mapRef.current;
         if (!map || !mapReady || !selectedTrek) return;
+
+        // Mark that we're NOT in globe view mode (we're viewing a trek)
+        isGlobeViewRef.current = false;
+        selectedTrekRef.current = selectedTrek.id;
 
         const trekData = trekDataMapRef.current[selectedTrek.id];
         const trekConfig = treksRef.current.find(t => t.id === selectedTrek.id);


### PR DESCRIPTION
Fixes the issue where zooming in on the globe, panning around, and then
zooming back out would cause the globe to remain off-center instead of
returning to the default centered position.

Changes:
- Add zoomend listener that detects when user zooms out to globe level
- Auto-recenter to [30, 15] if globe has drifted more than 5 degrees
- Track globe view mode vs trek view mode to avoid unwanted recentering
- Skip auto-recenter when flyToGlobe is already handling centering

Also adds E2E tests for globe centering behavior.