### PR TITLE
test: Add tests for critical hooks

### DIFF
--- a/src/hooks/useMedia.test.ts
+++ b/src/hooks/useMedia.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useMedia } from './useMedia';
+
+// Mock supabase
+const mockSubscription = { unsubscribe: vi.fn() };
+const mockOnAuthStateChange = vi.fn(() => ({
+    data: { subscription: mockSubscription }
+}));
+const mockGetSession = vi.fn();
+
+vi.mock('../lib/supabase', () => ({
+    supabase: {
+        auth: {
+            getSession: () => mockGetSession(),
+            onAuthStateChange: (callback: (event: string, session: unknown) => void) => mockOnAuthStateChange(callback),
+        }
+    }
+}));
+
+// Mock media utilities
+vi.mock('../lib/media', () => ({
+    buildMediaUrl: (path: string, token: string | null) => {
+        const baseUrl = 'https://media.example.com';
+        return token ? `${baseUrl}/${path}?token=${token}` : `${baseUrl}/${path}`;
+    },
+    getJourneyPhotoPath: (journeyId: string, photoId: string, extension: string) => {
+        return `journeys/${journeyId}/photos/${photoId}.${extension}`;
+    }
+}));
+
+describe('useMedia', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns loading state initially', () => {
+        mockGetSession.mockReturnValue(new Promise(() => {})); // Never resolves
+        const { result } = renderHook(() => useMedia());
+        expect(result.current.loading).toBe(true);
+    });
+
+    it('sets token from session', async () => {
+        mockGetSession.mockResolvedValue({
+            data: { session: { access_token: 'test-token-123' } }
+        });
+
+        const { result } = renderHook(() => useMedia());
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.token).toBe('test-token-123');
+    });
+
+    it('sets token to null when no session', async () => {
+        mockGetSession.mockResolvedValue({
+            data: { session: null }
+        });
+
+        const { result } = renderHook(() => useMedia());
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.token).toBeNull();
+    });
+
+    it('builds media URL with token', async () => {
+        mockGetSession.mockResolvedValue({
+            data: { session: { access_token: 'my-token' } }
+        });
+
+        const { result } = renderHook(() => useMedia());
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        const url = result.current.getMediaUrl('images/photo.jpg');
+        expect(url).toBe('https://media.example.com/images/photo.jpg?token=my-token');
+    });
+
+    it('builds media URL without token when not authenticated', async () => {
+        mockGetSession.mockResolvedValue({
+            data: { session: null }
+        });
+
+        const { result } = renderHook(() => useMedia());
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        const url = result.current.getMediaUrl('images/photo.jpg');
+        expect(url).toBe('https://media.example.com/images/photo.jpg');
+    });
+
+    it('builds photo URL with journey and photo IDs', async () => {
+        mockGetSession.mockResolvedValue({
+            data: { session: { access_token: 'token' } }
+        });
+
+        const { result } = renderHook(() => useMedia());
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        const url = result.current.getPhotoUrl('journey-123', 'photo-456');
+        expect(url).toBe('https://media.example.com/journeys/journey-123/photos/photo-456.jpg?token=token');
+    });
+
+    it('supports custom photo extension', async () => {
+        mockGetSession.mockResolvedValue({
+            data: { session: { access_token: 'token' } }
+        });
+
+        const { result } = renderHook(() => useMedia());
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        const url = result.current.getPhotoUrl('journey-123', 'photo-456', 'webp');
+        expect(url).toBe('https://media.example.com/journeys/journey-123/photos/photo-456.webp?token=token');
+    });
+
+    it('unsubscribes from auth changes on unmount', async () => {
+        mockGetSession.mockResolvedValue({
+            data: { session: null }
+        });
+
+        const { unmount } = renderHook(() => useMedia());
+
+        await waitFor(() => {
+            expect(mockOnAuthStateChange).toHaveBeenCalled();
+        });
+
+        unmount();
+
+        expect(mockSubscription.unsubscribe).toHaveBeenCalled();
+    });
+
+    it('memoizes getMediaUrl callback', async () => {
+        mockGetSession.mockResolvedValue({
+            data: { session: { access_token: 'token' } }
+        });
+
+        const { result, rerender } = renderHook(() => useMedia());
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        const firstCallback = result.current.getMediaUrl;
+        rerender();
+        const secondCallback = result.current.getMediaUrl;
+
+        // Callback should be stable (same reference) when token hasn't changed
+        expect(firstCallback).toBe(secondCallback);
+    });
+});

--- a/src/hooks/useOnlineStatus.test.ts
+++ b/src/hooks/useOnlineStatus.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useOnlineStatus, useCacheStatus, useCacheStorage } from './useOnlineStatus';
+
+describe('useOnlineStatus', () => {
+    let onlineGetter: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        // Mock navigator.onLine
+        onlineGetter = vi.spyOn(navigator, 'onLine', 'get');
+    });
+
+    afterEach(() => {
+        onlineGetter.mockRestore();
+        vi.clearAllMocks();
+    });
+
+    it('returns online status based on navigator.onLine', () => {
+        onlineGetter.mockReturnValue(true);
+        const { result } = renderHook(() => useOnlineStatus());
+        expect(result.current.isOnline).toBe(true);
+        expect(result.current.wasOffline).toBe(false);
+    });
+
+    it('returns offline status when navigator.onLine is false', () => {
+        onlineGetter.mockReturnValue(false);
+        const { result } = renderHook(() => useOnlineStatus());
+        expect(result.current.isOnline).toBe(false);
+    });
+
+    it('updates when going offline', async () => {
+        onlineGetter.mockReturnValue(true);
+        const { result } = renderHook(() => useOnlineStatus());
+
+        expect(result.current.isOnline).toBe(true);
+
+        // Simulate going offline
+        act(() => {
+            window.dispatchEvent(new Event('offline'));
+        });
+
+        expect(result.current.isOnline).toBe(false);
+        expect(result.current.wasOffline).toBe(true);
+    });
+
+    it('updates when coming online after being offline', async () => {
+        onlineGetter.mockReturnValue(true);
+        const { result } = renderHook(() => useOnlineStatus());
+
+        // First go offline
+        act(() => {
+            window.dispatchEvent(new Event('offline'));
+        });
+
+        expect(result.current.isOnline).toBe(false);
+        expect(result.current.wasOffline).toBe(true);
+
+        // Then come back online
+        act(() => {
+            window.dispatchEvent(new Event('online'));
+        });
+
+        expect(result.current.isOnline).toBe(true);
+        // wasOffline should stay true briefly (for reconnection message)
+        expect(result.current.wasOffline).toBe(true);
+    });
+
+    it('clears wasOffline after timeout when coming back online', async () => {
+        vi.useFakeTimers();
+        onlineGetter.mockReturnValue(false);
+        const { result } = renderHook(() => useOnlineStatus());
+
+        // Go offline first
+        act(() => {
+            window.dispatchEvent(new Event('offline'));
+        });
+
+        // Then come back online
+        act(() => {
+            window.dispatchEvent(new Event('online'));
+        });
+
+        expect(result.current.wasOffline).toBe(true);
+
+        // Fast-forward 3 seconds
+        act(() => {
+            vi.advanceTimersByTime(3000);
+        });
+
+        expect(result.current.wasOffline).toBe(false);
+
+        vi.useRealTimers();
+    });
+
+    it('cleans up event listeners on unmount', () => {
+        const addSpy = vi.spyOn(window, 'addEventListener');
+        const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+        onlineGetter.mockReturnValue(true);
+        const { unmount } = renderHook(() => useOnlineStatus());
+
+        expect(addSpy).toHaveBeenCalledWith('online', expect.any(Function));
+        expect(addSpy).toHaveBeenCalledWith('offline', expect.any(Function));
+
+        unmount();
+
+        expect(removeSpy).toHaveBeenCalledWith('online', expect.any(Function));
+        expect(removeSpy).toHaveBeenCalledWith('offline', expect.any(Function));
+
+        addSpy.mockRestore();
+        removeSpy.mockRestore();
+    });
+});
+
+describe('useCacheStatus', () => {
+    const mockCache = {
+        keys: vi.fn(),
+    };
+
+    beforeEach(() => {
+        // Mock caches API
+        Object.defineProperty(global, 'caches', {
+            value: {
+                open: vi.fn().mockResolvedValue(mockCache),
+            },
+            writable: true,
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns empty array when cache has no entries', async () => {
+        mockCache.keys.mockResolvedValue([]);
+
+        const { result } = renderHook(() => useCacheStatus('test-cache'));
+
+        await waitFor(() => {
+            expect(result.current.isChecking).toBe(false);
+        });
+
+        expect(result.current.cachedUrls).toEqual([]);
+    });
+
+    it('returns cached URLs', async () => {
+        mockCache.keys.mockResolvedValue([
+            { url: 'https://example.com/image1.jpg' },
+            { url: 'https://example.com/image2.jpg' },
+        ]);
+
+        const { result } = renderHook(() => useCacheStatus('test-cache'));
+
+        await waitFor(() => {
+            expect(result.current.isChecking).toBe(false);
+        });
+
+        expect(result.current.cachedUrls).toEqual([
+            'https://example.com/image1.jpg',
+            'https://example.com/image2.jpg',
+        ]);
+    });
+
+    it('provides refresh function', async () => {
+        mockCache.keys.mockResolvedValue([]);
+
+        const { result } = renderHook(() => useCacheStatus('test-cache'));
+
+        await waitFor(() => {
+            expect(result.current.isChecking).toBe(false);
+        });
+
+        expect(typeof result.current.refresh).toBe('function');
+    });
+});
+
+describe('useCacheStorage', () => {
+    beforeEach(() => {
+        // Mock navigator.storage
+        Object.defineProperty(global.navigator, 'storage', {
+            value: {
+                estimate: vi.fn().mockResolvedValue({
+                    usage: 1000000,
+                    quota: 10000000,
+                }),
+            },
+            writable: true,
+            configurable: true,
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns storage usage', async () => {
+        const { result } = renderHook(() => useCacheStorage());
+
+        await waitFor(() => {
+            expect(result.current).not.toBeNull();
+        });
+
+        expect(result.current).toEqual({
+            used: 1000000,
+            quota: 10000000,
+        });
+    });
+
+    it('returns null initially', () => {
+        const { result } = renderHook(() => useCacheStorage());
+        // Initially null before async completes
+        expect(result.current).toBeNull();
+    });
+});

--- a/src/hooks/usePhotoDay.test.ts
+++ b/src/hooks/usePhotoDay.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { usePhotoDay } from './usePhotoDay';
+import type { TrekData, Photo, Camp } from '../types/trek';
+
+// Helper to create mock trek data
+function createMockTrekData(overrides: Partial<TrekData> = {}): TrekData {
+    return {
+        id: 'test-trek',
+        name: 'Test Trek',
+        country: 'Test Country',
+        description: 'A test trek',
+        stats: {
+            duration: 3,
+            totalDistance: 30,
+            totalElevationGain: 2000,
+            highestPoint: { name: 'Summit', elevation: 5000 }
+        },
+        camps: [
+            {
+                id: 'camp-1',
+                name: 'Camp 1',
+                dayNumber: 1,
+                elevation: 2000,
+                coordinates: [37.0, -3.0],
+                elevationGainFromPrevious: 0,
+                notes: '',
+                highlights: [],
+                routeDistanceKm: 0,
+                routePointIndex: 0,
+            },
+            {
+                id: 'camp-2',
+                name: 'Camp 2',
+                dayNumber: 2,
+                elevation: 3000,
+                coordinates: [37.1, -3.1],
+                elevationGainFromPrevious: 1000,
+                notes: '',
+                highlights: [],
+                routeDistanceKm: 10,
+                routePointIndex: 50,
+            },
+            {
+                id: 'camp-3',
+                name: 'Camp 3',
+                dayNumber: 3,
+                elevation: 4000,
+                coordinates: [37.2, -3.2],
+                elevationGainFromPrevious: 1000,
+                notes: '',
+                highlights: [],
+                routeDistanceKm: 20,
+                routePointIndex: 100,
+            },
+        ],
+        route: {
+            type: 'LineString',
+            coordinates: Array.from({ length: 101 }, (_, i) => [
+                37.0 + (i * 0.002),
+                -3.0 - (i * 0.002),
+                2000 + (i * 20)
+            ])
+        },
+        dateStarted: '2024-01-01',
+        ...overrides
+    };
+}
+
+// Helper to create mock photo
+function createMockPhoto(overrides: Partial<Photo> = {}): Photo {
+    return {
+        id: `photo-${Math.random().toString(36).substr(2, 9)}`,
+        journey_id: 'test-journey',
+        url: 'https://example.com/photo.jpg',
+        ...overrides
+    } as Photo;
+}
+
+describe('usePhotoDay', () => {
+    describe('waypointToDayMap', () => {
+        it('builds a map from waypoint IDs to day numbers', () => {
+            const trekData = createMockTrekData();
+            const { result } = renderHook(() => usePhotoDay(trekData, []));
+
+            expect(result.current.waypointToDayMap.get('camp-1')).toBe(1);
+            expect(result.current.waypointToDayMap.get('camp-2')).toBe(2);
+            expect(result.current.waypointToDayMap.get('camp-3')).toBe(3);
+        });
+
+        it('returns empty map when no camps', () => {
+            const trekData = createMockTrekData({ camps: [] });
+            const { result } = renderHook(() => usePhotoDay(trekData, []));
+
+            expect(result.current.waypointToDayMap.size).toBe(0);
+        });
+    });
+
+    describe('getPhotoDay - Tier 1: Explicit waypoint_id', () => {
+        it('returns day number from explicit waypoint_id assignment', () => {
+            const trekData = createMockTrekData();
+            const photo = createMockPhoto({ waypoint_id: 'camp-2' });
+
+            const { result } = renderHook(() => usePhotoDay(trekData, [photo]));
+
+            expect(result.current.getPhotoDay(photo)).toBe(2);
+        });
+
+        it('ignores invalid waypoint_id', () => {
+            const trekData = createMockTrekData();
+            const photo = createMockPhoto({ waypoint_id: 'invalid-camp' });
+
+            const { result } = renderHook(() => usePhotoDay(trekData, [photo]));
+
+            // Should fall through to other methods (returns null if no other matches)
+            expect(result.current.getPhotoDay(photo)).toBeNull();
+        });
+    });
+
+    describe('getPhotoDay - Tier 2: Date matching', () => {
+        it('matches photo by date relative to journey start', () => {
+            const trekData = createMockTrekData({ dateStarted: '2024-01-01' });
+            const photo = createMockPhoto({
+                taken_at: '2024-01-02T12:00:00Z' // Day 2
+            });
+
+            const { result } = renderHook(() => usePhotoDay(trekData, [photo]));
+
+            expect(result.current.getPhotoDay(photo)).toBe(2);
+        });
+
+        it('returns day 1 for photo on start date', () => {
+            const trekData = createMockTrekData({ dateStarted: '2024-01-01' });
+            const photo = createMockPhoto({
+                taken_at: '2024-01-01T15:00:00Z' // Day 1
+            });
+
+            const { result } = renderHook(() => usePhotoDay(trekData, [photo]));
+
+            expect(result.current.getPhotoDay(photo)).toBe(1);
+        });
+
+        it('ignores date if outside journey duration', () => {
+            const trekData = createMockTrekData({ dateStarted: '2024-01-01' }); // 3 day trek
+            const photo = createMockPhoto({
+                taken_at: '2024-01-10T12:00:00Z' // Day 10 - outside trek
+            });
+
+            const { result } = renderHook(() => usePhotoDay(trekData, [photo]));
+
+            // Should fall through to location-based matching or return null
+            expect(result.current.getPhotoDay(photo)).toBeNull();
+        });
+
+        it('skips date matching if journey has no start date', () => {
+            const trekData = createMockTrekData({ dateStarted: undefined });
+            const photo = createMockPhoto({
+                taken_at: '2024-01-02T12:00:00Z'
+            });
+
+            const { result } = renderHook(() => usePhotoDay(trekData, [photo]));
+
+            // Should fall through to other methods
+            expect(result.current.getPhotoDay(photo)).toBeNull();
+        });
+    });
+
+    describe('getPhotoDay - Tier 3: Location-based route matching', () => {
+        it('matches photo near route to correct day segment', () => {
+            const trekData = createMockTrekData();
+            // Photo coordinates near route point ~60 (between camp 2 at index 50 and camp 3 at index 100)
+            const photo = createMockPhoto({
+                coordinates: [37.12, -3.12] // Near route point ~60
+            });
+
+            const { result } = renderHook(() => usePhotoDay(trekData, [photo]));
+
+            // Should match to day 3 (next camp after route point 60)
+            expect(result.current.getPhotoDay(photo)).toBe(3);
+        });
+
+        it('matches photo before first camp to day 1', () => {
+            const trekData = createMockTrekData();
+            // Photo at start of route
+            const photo = createMockPhoto({
+                coordinates: [37.0, -3.0]
+            });
+
+            const { result } = renderHook(() => usePhotoDay(trekData, [photo]));
+
+            expect(result.current.getPhotoDay(photo)).toBe(1);
+        });
+
+        it('ignores photo far from route (>2km)', () => {
+            const trekData = createMockTrekData();
+            // Photo coordinates far from route
+            const photo = createMockPhoto({
+                coordinates: [40.0, -5.0] // ~300km away
+            });
+
+            const { result } = renderHook(() => usePhotoDay(trekData, [photo]));
+
+            // Should fall through to nearest camp fallback, but also likely >5km away
+            expect(result.current.getPhotoDay(photo)).toBeNull();
+        });
+    });
+
+    describe('getPhotoDay - Tier 4: Nearest camp fallback', () => {
+        it('matches photo to nearest camp within 5km', () => {
+            const trekData = createMockTrekData({ route: undefined }); // No route for this test
+            // Photo near camp 2
+            const photo = createMockPhoto({
+                coordinates: [37.105, -3.105] // Close to camp-2 at [37.1, -3.1]
+            });
+
+            const { result } = renderHook(() => usePhotoDay(trekData, [photo]));
+
+            expect(result.current.getPhotoDay(photo)).toBe(2);
+        });
+
+        it('returns null if photo is >5km from all camps', () => {
+            const trekData = createMockTrekData({ route: undefined });
+            const photo = createMockPhoto({
+                coordinates: [50.0, -10.0] // Far from all camps
+            });
+
+            const { result } = renderHook(() => usePhotoDay(trekData, [photo]));
+
+            expect(result.current.getPhotoDay(photo)).toBeNull();
+        });
+    });
+
+    describe('getPhotosForDay', () => {
+        it('returns all photos for a specific day', () => {
+            const trekData = createMockTrekData();
+            const photos = [
+                createMockPhoto({ id: 'p1', waypoint_id: 'camp-1' }),
+                createMockPhoto({ id: 'p2', waypoint_id: 'camp-2' }),
+                createMockPhoto({ id: 'p3', waypoint_id: 'camp-1' }),
+                createMockPhoto({ id: 'p4', waypoint_id: 'camp-2' }),
+            ];
+
+            const { result } = renderHook(() => usePhotoDay(trekData, photos));
+
+            const day1Photos = result.current.getPhotosForDay(1);
+            expect(day1Photos).toHaveLength(2);
+            expect(day1Photos.map(p => p.id)).toEqual(['p1', 'p3']);
+
+            const day2Photos = result.current.getPhotosForDay(2);
+            expect(day2Photos).toHaveLength(2);
+            expect(day2Photos.map(p => p.id)).toEqual(['p2', 'p4']);
+        });
+
+        it('returns empty array for day with no photos', () => {
+            const trekData = createMockTrekData();
+            const photos = [
+                createMockPhoto({ waypoint_id: 'camp-1' }),
+            ];
+
+            const { result } = renderHook(() => usePhotoDay(trekData, photos));
+
+            expect(result.current.getPhotosForDay(3)).toEqual([]);
+        });
+    });
+
+    describe('photosByDay', () => {
+        it('groups photos by day number', () => {
+            const trekData = createMockTrekData();
+            const photos = [
+                createMockPhoto({ id: 'p1', waypoint_id: 'camp-1' }),
+                createMockPhoto({ id: 'p2', waypoint_id: 'camp-2' }),
+                createMockPhoto({ id: 'p3', waypoint_id: 'camp-3' }),
+            ];
+
+            const { result } = renderHook(() => usePhotoDay(trekData, photos));
+
+            expect(result.current.photosByDay[1]).toHaveLength(1);
+            expect(result.current.photosByDay[2]).toHaveLength(1);
+            expect(result.current.photosByDay[3]).toHaveLength(1);
+            expect(result.current.photosByDay.unassigned).toHaveLength(0);
+        });
+
+        it('puts unmatched photos in unassigned group', () => {
+            const trekData = createMockTrekData({ route: undefined });
+            const photos = [
+                createMockPhoto({ id: 'p1', waypoint_id: 'camp-1' }),
+                createMockPhoto({ id: 'p2' }), // No waypoint, no date, no coords
+                createMockPhoto({ id: 'p3', coordinates: [100, 100] }), // Far from everything
+            ];
+
+            const { result } = renderHook(() => usePhotoDay(trekData, photos));
+
+            expect(result.current.photosByDay[1]).toHaveLength(1);
+            expect(result.current.photosByDay.unassigned).toHaveLength(2);
+        });
+
+        it('initializes all day groups even with no photos', () => {
+            const trekData = createMockTrekData();
+
+            const { result } = renderHook(() => usePhotoDay(trekData, []));
+
+            expect(result.current.photosByDay[1]).toEqual([]);
+            expect(result.current.photosByDay[2]).toEqual([]);
+            expect(result.current.photosByDay[3]).toEqual([]);
+            expect(result.current.photosByDay.unassigned).toEqual([]);
+        });
+    });
+
+    describe('memoization', () => {
+        it('memoizes waypointToDayMap when camps do not change', () => {
+            const trekData = createMockTrekData();
+            const { result, rerender } = renderHook(() => usePhotoDay(trekData, []));
+
+            const firstMap = result.current.waypointToDayMap;
+            rerender();
+            const secondMap = result.current.waypointToDayMap;
+
+            expect(firstMap).toBe(secondMap);
+        });
+
+        it('updates waypointToDayMap when camps change', () => {
+            const trekData1 = createMockTrekData();
+            const { result, rerender } = renderHook(
+                ({ data }) => usePhotoDay(data, []),
+                { initialProps: { data: trekData1 } }
+            );
+
+            const firstMap = result.current.waypointToDayMap;
+
+            const trekData2 = createMockTrekData({
+                camps: [
+                    ...trekData1.camps,
+                    {
+                        id: 'camp-4',
+                        name: 'Camp 4',
+                        dayNumber: 4,
+                        elevation: 5000,
+                        coordinates: [37.3, -3.3],
+                        elevationGainFromPrevious: 1000,
+                        notes: '',
+                        highlights: [],
+                    },
+                ]
+            });
+
+            rerender({ data: trekData2 });
+            const secondMap = result.current.waypointToDayMap;
+
+            expect(firstMap).not.toBe(secondMap);
+            expect(secondMap.get('camp-4')).toBe(4);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Add comprehensive test coverage for previously untested hooks as a foundation for future refactoring.

### New Tests

**useOnlineStatus (11 tests)**
- Online/offline state detection
- `wasOffline` behavior for reconnection messages
- Timeout clearing after coming back online
- Event listener cleanup on unmount
- Cache status and storage usage hooks

**useMedia (9 tests)**
- Token management from Supabase session
- URL building with/without authentication
- Photo URL generation with custom extensions
- Auth subscription cleanup
- Callback memoization

**usePhotoDay (20 tests)**
- Tier 1: Explicit waypoint_id assignment
- Tier 2: Date matching relative to journey start
- Tier 3: Location-based route segment matching
- Tier 4: Nearest camp fallback
- Photo grouping by day
- Memoization behavior

### Test Coverage

- **Before**: 229 tests
- **After**: 269 tests (+40)

### Future Work

- RouteEditor.tsx tests (complex component, needs dedicated effort)
- Additional component integration tests

## Test plan

- [x] All 269 tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)