### PR TITLE
feat: Add fun facts and discoveries for journey days

### DIFF
--- a/scripts/populateFunFacts.ts
+++ b/scripts/populateFunFacts.ts
@@ -1,0 +1,386 @@
+/**
+ * Script to populate fun facts, POIs, and historical sites for journey waypoints
+ *
+ * Usage: SUPABASE_SERVICE_KEY="..." npx tsx scripts/populateFunFacts.ts
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = 'https://pbqvnxeldpgvcrdbxcvr.supabase.co';
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
+
+if (!SUPABASE_SERVICE_KEY) {
+    console.error('❌ SUPABASE_SERVICE_KEY environment variable is required');
+    process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+// Fun facts organized by journey slug and day number
+const FUN_FACTS_DATA: Record<string, Record<number, {
+    funFacts?: Array<{
+        id: string;
+        content: string;
+        category: string;
+        source?: string;
+        learn_more_url?: string;
+    }>;
+    pointsOfInterest?: Array<{
+        id: string;
+        name: string;
+        category: string;
+        coordinates: [number, number];
+        elevation?: number;
+        description?: string;
+        tips?: string[];
+    }>;
+    historicalSites?: Array<{
+        id: string;
+        name: string;
+        coordinates: [number, number];
+        summary: string;
+        description?: string;
+        period?: string;
+        significance?: 'major' | 'minor' | 'notable';
+        tags?: string[];
+        links?: Array<{ label: string; url: string }>;
+    }>;
+}>> = {
+    // Kilimanjaro - Lemosho Route
+    'kilimanjaro': {
+        1: {
+            funFacts: [
+                {
+                    id: 'kili-1-1',
+                    content: 'Kilimanjaro is the tallest free-standing mountain in the world, rising 5,895 meters from the surrounding plains without being part of a mountain range.',
+                    category: 'geology',
+                    source: 'National Geographic',
+                },
+                {
+                    id: 'kili-1-2',
+                    content: 'The Lemosho Route passes through 5 distinct climate zones in just 6 days - from tropical rainforest to arctic summit!',
+                    category: 'climate',
+                },
+                {
+                    id: 'kili-1-3',
+                    content: 'Blue monkeys and black-and-white colobus monkeys are commonly spotted in this rainforest zone. Listen for their calls!',
+                    category: 'wildlife',
+                },
+            ],
+            pointsOfInterest: [
+                {
+                    id: 'kili-poi-1-1',
+                    name: 'Londorossi Gate',
+                    category: 'info',
+                    coordinates: [37.1089, -3.0175],
+                    elevation: 2100,
+                    description: 'The official park registration point for the Lemosho Route. Named after a nearby village.',
+                    tips: ['Bring your passport for registration', 'Use the restroom facilities here'],
+                },
+            ],
+        },
+        2: {
+            funFacts: [
+                {
+                    id: 'kili-2-1',
+                    content: 'The giant heather plants in this zone can grow up to 10 meters tall - much larger than their European cousins which only reach about 60cm.',
+                    category: 'flora',
+                },
+                {
+                    id: 'kili-2-2',
+                    content: 'Kilimanjaro generates its own weather. Moisture from the Indian Ocean hits the mountain and creates a unique microclimate.',
+                    category: 'climate',
+                    source: 'Kilimanjaro Research Program',
+                },
+            ],
+            pointsOfInterest: [
+                {
+                    id: 'kili-poi-2-1',
+                    name: 'Shira Plateau Viewpoint',
+                    category: 'viewpoint',
+                    coordinates: [37.2456, -3.0678],
+                    elevation: 3500,
+                    description: 'Panoramic views of the Shira Plateau, one of Kilimanjaro\'s three volcanic cones.',
+                },
+            ],
+        },
+        3: {
+            funFacts: [
+                {
+                    id: 'kili-3-1',
+                    content: 'The Shira Plateau is the remains of an ancient volcano that collapsed around 500,000 years ago. It was once as tall as Kibo peak is today.',
+                    category: 'geology',
+                },
+                {
+                    id: 'kili-3-2',
+                    content: 'At this altitude, water boils at about 87°C instead of 100°C, which is why camp cooking takes longer!',
+                    category: 'science',
+                },
+                {
+                    id: 'kili-3-3',
+                    content: '"Pole pole" (slowly slowly) is the Swahili mantra for climbing Kilimanjaro. A slow pace helps your body acclimatize.',
+                    category: 'survival',
+                },
+            ],
+        },
+        4: {
+            funFacts: [
+                {
+                    id: 'kili-4-1',
+                    content: 'The Lava Tower is a 300-foot volcanic plug formed when lava hardened inside a volcanic vent. It\'s over 100,000 years old.',
+                    category: 'geology',
+                },
+                {
+                    id: 'kili-4-2',
+                    content: 'Today\'s route follows the "climb high, sleep low" acclimatization strategy - you\'ll go up to 4,600m then descend to camp at 3,900m.',
+                    category: 'survival',
+                },
+            ],
+            pointsOfInterest: [
+                {
+                    id: 'kili-poi-4-1',
+                    name: 'Lava Tower',
+                    category: 'landmark',
+                    coordinates: [37.3156, -3.0823],
+                    elevation: 4630,
+                    description: 'An impressive 300-foot volcanic rock formation. Technical climbers sometimes scale its face.',
+                    tips: ['Great acclimatization stop', 'Take a hot drink at the tower base'],
+                },
+            ],
+        },
+        5: {
+            funFacts: [
+                {
+                    id: 'kili-5-1',
+                    content: 'The Barranco Wall, though intimidating, has a summit success rate of over 95%. It\'s a scramble, not a technical climb.',
+                    category: 'adventure',
+                },
+                {
+                    id: 'kili-5-2',
+                    content: 'Giant Senecios (groundsels) found here are prehistoric plants that have evolved to survive freezing nights and intense UV radiation.',
+                    category: 'flora',
+                    source: 'Botanical Journal of Tanzania',
+                },
+            ],
+            pointsOfInterest: [
+                {
+                    id: 'kili-poi-5-1',
+                    name: 'Barranco Wall',
+                    category: 'landmark',
+                    coordinates: [37.3389, -3.0912],
+                    elevation: 3950,
+                    description: 'The famous "Breakfast Wall" - a 257m rock scramble that\'s the highlight of many climbers\' journeys.',
+                    tips: ['Follow your guide\'s exact path', 'Keep three points of contact', 'Don\'t look down!'],
+                },
+            ],
+        },
+        6: {
+            funFacts: [
+                {
+                    id: 'kili-6-1',
+                    content: 'The glaciers on Kilimanjaro have shrunk by 85% since 1912. Scientists estimate they could disappear entirely by 2040.',
+                    category: 'climate',
+                    source: 'Ohio State University Research',
+                    learn_more_url: 'https://news.osu.edu/kilimanjaro-ice-study/',
+                },
+                {
+                    id: 'kili-6-2',
+                    content: 'You\'re now in the alpine desert zone. Despite looking barren, this area hosts specialized plants and animals adapted to extreme conditions.',
+                    category: 'flora',
+                },
+            ],
+        },
+        7: {
+            funFacts: [
+                {
+                    id: 'kili-7-1',
+                    content: 'Uhuru Peak means "Freedom Peak" in Swahili. It was renamed in 1961 when Tanzania gained independence from British rule.',
+                    category: 'history',
+                },
+                {
+                    id: 'kili-7-2',
+                    content: 'At the summit, there\'s about 50% less oxygen than at sea level. Your body is working twice as hard just to breathe!',
+                    category: 'science',
+                },
+                {
+                    id: 'kili-7-3',
+                    content: 'The oldest person to summit Kilimanjaro was Anne Lorimor at age 89 in 2019!',
+                    category: 'adventure',
+                    source: 'Guinness World Records',
+                },
+            ],
+            historicalSites: [
+                {
+                    id: 'kili-hist-7-1',
+                    name: 'Uhuru Peak',
+                    coordinates: [37.3556, -3.0758],
+                    summary: 'The highest point in Africa at 5,895m. Named for Tanzanian independence in 1961.',
+                    description: 'Hans Meyer and Ludwig Purtscheller became the first Europeans to reach this summit on October 6, 1889. The peak was originally called Kaiser Wilhelm Spitze but renamed Uhuru (Freedom) Peak when Tanzania gained independence.',
+                    period: '1889 - Present',
+                    significance: 'major',
+                    tags: ['summit', 'independence', 'first ascent'],
+                    links: [
+                        { label: 'Wikipedia', url: 'https://en.wikipedia.org/wiki/Mount_Kilimanjaro' },
+                    ],
+                },
+            ],
+            pointsOfInterest: [
+                {
+                    id: 'kili-poi-7-1',
+                    name: 'Stella Point',
+                    category: 'summit',
+                    coordinates: [37.3512, -3.0789],
+                    elevation: 5756,
+                    description: 'The crater rim point where most climbers reach at sunrise. Just 1 more hour to Uhuru!',
+                },
+                {
+                    id: 'kili-poi-7-2',
+                    name: 'Furtwängler Glacier',
+                    category: 'landmark',
+                    coordinates: [37.3534, -3.0756],
+                    elevation: 5800,
+                    description: 'One of the last remaining glaciers near the summit, named after German climber Walter Furtwängler.',
+                },
+            ],
+        },
+        8: {
+            funFacts: [
+                {
+                    id: 'kili-8-1',
+                    content: 'The descent from summit to Mweka Gate covers over 3,700m of elevation loss in just one day - be kind to your knees!',
+                    category: 'survival',
+                },
+                {
+                    id: 'kili-8-2',
+                    content: 'You\'ll receive an official summit certificate at the gate - green for reaching Stella Point (5,756m), gold for Uhuru Peak (5,895m).',
+                    category: 'adventure',
+                },
+            ],
+        },
+    },
+    // Add more journeys here...
+};
+
+interface WaypointWithJourney {
+    id: string;
+    name: string;
+    day_number: number;
+    fun_facts: unknown;
+    points_of_interest: unknown;
+    historical_sites: unknown;
+    journeys: {
+        slug: string;
+        name: string;
+    };
+}
+
+async function main() {
+    console.log('💡 Populating fun facts, POIs, and historical sites...\n');
+
+    // Fetch all waypoints with their journey slug
+    const { data: waypoints, error } = await supabase
+        .from('waypoints')
+        .select(`
+            id,
+            name,
+            day_number,
+            fun_facts,
+            points_of_interest,
+            historical_sites,
+            journeys!inner (
+                slug,
+                name
+            )
+        `)
+        .not('day_number', 'is', null)
+        .order('day_number');
+
+    if (error) {
+        console.error('❌ Error fetching waypoints:', error);
+        process.exit(1);
+    }
+
+    if (!waypoints || waypoints.length === 0) {
+        console.log('No waypoints found.');
+        return;
+    }
+
+    console.log(`Found ${waypoints.length} waypoints to process.\n`);
+
+    let updated = 0;
+    let skipped = 0;
+
+    for (const waypoint of waypoints as unknown as WaypointWithJourney[]) {
+        const journey = waypoint.journeys;
+        const journeyData = FUN_FACTS_DATA[journey.slug];
+
+        if (!journeyData) {
+            console.log(`⏭️  ${journey.name}: No data configured for this journey`);
+            skipped++;
+            continue;
+        }
+
+        const dayData = journeyData[waypoint.day_number];
+
+        if (!dayData) {
+            console.log(`⏭️  ${journey.name} Day ${waypoint.day_number}: No data for this day`);
+            skipped++;
+            continue;
+        }
+
+        // Check if already has data
+        const hasFunFacts = Array.isArray(waypoint.fun_facts) && waypoint.fun_facts.length > 0;
+        const hasPOIs = Array.isArray(waypoint.points_of_interest) && waypoint.points_of_interest.length > 0;
+        const hasHistoricalSites = Array.isArray(waypoint.historical_sites) && waypoint.historical_sites.length > 0;
+
+        if (hasFunFacts && hasPOIs && hasHistoricalSites) {
+            console.log(`⏭️  ${journey.name} Day ${waypoint.day_number}: ${waypoint.name} (already has all data)`);
+            skipped++;
+            continue;
+        }
+
+        console.log(`🔄 ${journey.name} Day ${waypoint.day_number}: ${waypoint.name}`);
+
+        const updateData: Record<string, unknown> = {};
+
+        if (dayData.funFacts && !hasFunFacts) {
+            updateData.fun_facts = dayData.funFacts;
+            console.log(`   💡 Adding ${dayData.funFacts.length} fun facts`);
+        }
+
+        if (dayData.pointsOfInterest && !hasPOIs) {
+            updateData.points_of_interest = dayData.pointsOfInterest;
+            console.log(`   📍 Adding ${dayData.pointsOfInterest.length} points of interest`);
+        }
+
+        if (dayData.historicalSites && !hasHistoricalSites) {
+            updateData.historical_sites = dayData.historicalSites;
+            console.log(`   🏛️ Adding ${dayData.historicalSites.length} historical sites`);
+        }
+
+        if (Object.keys(updateData).length === 0) {
+            console.log(`   ⏭️ No new data to add`);
+            skipped++;
+            continue;
+        }
+
+        // Update waypoint in database
+        const { error: updateError } = await supabase
+            .from('waypoints')
+            .update(updateData)
+            .eq('id', waypoint.id);
+
+        if (updateError) {
+            console.log(`   ❌ Update failed:`, updateError.message);
+        } else {
+            console.log(`   ✅ Updated`);
+            updated++;
+        }
+    }
+
+    console.log('\n📊 Summary:');
+    console.log(`   ✅ Updated: ${updated}`);
+    console.log(`   ⏭️ Skipped: ${skipped}`);
+}
+
+main().catch(console.error);

--- a/scripts/populateFunFacts.ts
+++ b/scripts/populateFunFacts.ts
@@ -16,39 +16,50 @@ if (!SUPABASE_SERVICE_KEY) {
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
-// Fun facts organized by journey slug and day number
-const FUN_FACTS_DATA: Record<string, Record<number, {
-    funFacts?: Array<{
-        id: string;
-        content: string;
-        category: string;
-        source?: string;
-        learn_more_url?: string;
-    }>;
-    pointsOfInterest?: Array<{
-        id: string;
-        name: string;
-        category: string;
-        coordinates: [number, number];
-        elevation?: number;
-        description?: string;
-        tips?: string[];
-    }>;
-    historicalSites?: Array<{
-        id: string;
-        name: string;
-        coordinates: [number, number];
-        summary: string;
-        description?: string;
-        period?: string;
-        significance?: 'major' | 'minor' | 'notable';
-        tags?: string[];
-        links?: Array<{ label: string; url: string }>;
-    }>;
-}>> = {
-    // Kilimanjaro - Lemosho Route
+interface FunFact {
+    id: string;
+    content: string;
+    category: string;
+    source?: string;
+    learn_more_url?: string;
+}
+
+interface PointOfInterest {
+    id: string;
+    name: string;
+    category: string;
+    coordinates: [number, number];
+    elevation?: number;
+    description?: string;
+    tips?: string[];
+}
+
+interface HistoricalSite {
+    id: string;
+    name: string;
+    coordinates: [number, number];
+    summary: string;
+    description?: string;
+    period?: string;
+    significance?: 'major' | 'minor' | 'notable';
+    tags?: string[];
+    links?: Array<{ label: string; url: string }>;
+}
+
+interface WaypointData {
+    funFacts?: FunFact[];
+    pointsOfInterest?: PointOfInterest[];
+    historicalSites?: HistoricalSite[];
+}
+
+// Fun facts organized by journey slug and waypoint name
+// Using waypoint name as key allows multiple waypoints per day
+const FUN_FACTS_DATA: Record<string, Record<string, WaypointData>> = {
+    // ============================================
+    // KILIMANJARO - LEMOSHO ROUTE (7 days)
+    // ============================================
     'kilimanjaro': {
-        1: {
+        'Mti Mkubwa (Big Tree Camp)': {
             funFacts: [
                 {
                     id: 'kili-1-1',
@@ -58,12 +69,12 @@ const FUN_FACTS_DATA: Record<string, Record<number, {
                 },
                 {
                     id: 'kili-1-2',
-                    content: 'The Lemosho Route passes through 5 distinct climate zones in just 6 days - from tropical rainforest to arctic summit!',
+                    content: 'The Lemosho Route passes through 5 distinct climate zones - from tropical rainforest to arctic summit. Today you hiked through the rainforest zone!',
                     category: 'climate',
                 },
                 {
                     id: 'kili-1-3',
-                    content: 'Blue monkeys and black-and-white colobus monkeys are commonly spotted in this rainforest zone. Listen for their calls!',
+                    content: 'Blue monkeys and black-and-white colobus monkeys are commonly spotted in this rainforest zone. The colobus has no thumb - unique among primates!',
                     category: 'wildlife',
                 },
             ],
@@ -79,7 +90,7 @@ const FUN_FACTS_DATA: Record<string, Record<number, {
                 },
             ],
         },
-        2: {
+        'Shira II Camp': {
             funFacts: [
                 {
                     id: 'kili-2-1',
@@ -88,9 +99,14 @@ const FUN_FACTS_DATA: Record<string, Record<number, {
                 },
                 {
                     id: 'kili-2-2',
-                    content: 'Kilimanjaro generates its own weather. Moisture from the Indian Ocean hits the mountain and creates a unique microclimate.',
+                    content: 'Kilimanjaro generates its own weather. Moisture from the Indian Ocean hits the mountain and creates a unique microclimate with afternoon clouds.',
                     category: 'climate',
                     source: 'Kilimanjaro Research Program',
+                },
+                {
+                    id: 'kili-2-3',
+                    content: 'The Shira Plateau is the remains of an ancient volcano that collapsed around 500,000 years ago. It was once as tall as Kibo peak is today!',
+                    category: 'geology',
                 },
             ],
             pointsOfInterest: [
@@ -100,16 +116,16 @@ const FUN_FACTS_DATA: Record<string, Record<number, {
                     category: 'viewpoint',
                     coordinates: [37.2456, -3.0678],
                     elevation: 3500,
-                    description: 'Panoramic views of the Shira Plateau, one of Kilimanjaro\'s three volcanic cones.',
+                    description: 'Panoramic views of the Shira Plateau, one of Kilimanjaro\'s three volcanic cones that collapsed 500,000 years ago.',
                 },
             ],
         },
-        3: {
+        'Barranco Camp': {
             funFacts: [
                 {
                     id: 'kili-3-1',
-                    content: 'The Shira Plateau is the remains of an ancient volcano that collapsed around 500,000 years ago. It was once as tall as Kibo peak is today.',
-                    category: 'geology',
+                    content: 'Today\'s route followed the "climb high, sleep low" strategy - you went up to Lava Tower (4,630m) then descended to camp at 3,987m for better acclimatization.',
+                    category: 'survival',
                 },
                 {
                     id: 'kili-3-2',
@@ -118,53 +134,44 @@ const FUN_FACTS_DATA: Record<string, Record<number, {
                 },
                 {
                     id: 'kili-3-3',
-                    content: '"Pole pole" (slowly slowly) is the Swahili mantra for climbing Kilimanjaro. A slow pace helps your body acclimatize.',
+                    content: '"Pole pole" (slowly slowly) is the Swahili mantra for climbing Kilimanjaro. A slow pace helps your body acclimatize to the thin air.',
                     category: 'survival',
                 },
             ],
+            pointsOfInterest: [
+                {
+                    id: 'kili-poi-3-1',
+                    name: 'Lava Tower',
+                    category: 'landmark',
+                    coordinates: [37.3156, -3.0823],
+                    elevation: 4630,
+                    description: 'A 300-foot volcanic plug formed when lava hardened inside a volcanic vent over 100,000 years ago. Technical climbers sometimes scale its face.',
+                    tips: ['Great acclimatization stop', 'Take a hot drink at the tower base'],
+                },
+            ],
         },
-        4: {
+        'Karanga Camp': {
             funFacts: [
                 {
                     id: 'kili-4-1',
-                    content: 'The Lava Tower is a 300-foot volcanic plug formed when lava hardened inside a volcanic vent. It\'s over 100,000 years old.',
-                    category: 'geology',
+                    content: 'The Barranco Wall you climbed this morning, though intimidating, has a success rate of over 95%. It\'s a scramble, not a technical climb!',
+                    category: 'adventure',
                 },
                 {
                     id: 'kili-4-2',
-                    content: 'Today\'s route follows the "climb high, sleep low" acclimatization strategy - you\'ll go up to 4,600m then descend to camp at 3,900m.',
-                    category: 'survival',
+                    content: 'Giant Senecios (groundsels) found here are prehistoric plants that have evolved to survive freezing nights and intense UV radiation at high altitude.',
+                    category: 'flora',
+                    source: 'Botanical Journal of Tanzania',
+                },
+                {
+                    id: 'kili-4-3',
+                    content: 'Karanga means "little food" in Swahili - this was historically the last water point before the summit push.',
+                    category: 'culture',
                 },
             ],
             pointsOfInterest: [
                 {
                     id: 'kili-poi-4-1',
-                    name: 'Lava Tower',
-                    category: 'landmark',
-                    coordinates: [37.3156, -3.0823],
-                    elevation: 4630,
-                    description: 'An impressive 300-foot volcanic rock formation. Technical climbers sometimes scale its face.',
-                    tips: ['Great acclimatization stop', 'Take a hot drink at the tower base'],
-                },
-            ],
-        },
-        5: {
-            funFacts: [
-                {
-                    id: 'kili-5-1',
-                    content: 'The Barranco Wall, though intimidating, has a summit success rate of over 95%. It\'s a scramble, not a technical climb.',
-                    category: 'adventure',
-                },
-                {
-                    id: 'kili-5-2',
-                    content: 'Giant Senecios (groundsels) found here are prehistoric plants that have evolved to survive freezing nights and intense UV radiation.',
-                    category: 'flora',
-                    source: 'Botanical Journal of Tanzania',
-                },
-            ],
-            pointsOfInterest: [
-                {
-                    id: 'kili-poi-5-1',
                     name: 'Barranco Wall',
                     category: 'landmark',
                     coordinates: [37.3389, -3.0912],
@@ -174,36 +181,41 @@ const FUN_FACTS_DATA: Record<string, Record<number, {
                 },
             ],
         },
-        6: {
+        'Barafu Camp (Base Camp)': {
             funFacts: [
                 {
-                    id: 'kili-6-1',
+                    id: 'kili-5-1',
                     content: 'The glaciers on Kilimanjaro have shrunk by 85% since 1912. Scientists estimate they could disappear entirely by 2040.',
                     category: 'climate',
                     source: 'Ohio State University Research',
                     learn_more_url: 'https://news.osu.edu/kilimanjaro-ice-study/',
                 },
                 {
-                    id: 'kili-6-2',
-                    content: 'You\'re now in the alpine desert zone. Despite looking barren, this area hosts specialized plants and animals adapted to extreme conditions.',
+                    id: 'kili-5-2',
+                    content: 'You\'re now in the alpine desert zone at 4,655m. Despite looking barren, specialized lichens and insects survive here.',
                     category: 'flora',
+                },
+                {
+                    id: 'kili-5-3',
+                    content: '"Barafu" means "ice" in Swahili - a reminder of the glaciers that once extended much lower on the mountain.',
+                    category: 'culture',
                 },
             ],
         },
-        7: {
+        'Uhuru Peak (Summit)': {
             funFacts: [
                 {
-                    id: 'kili-7-1',
+                    id: 'kili-6-1',
                     content: 'Uhuru Peak means "Freedom Peak" in Swahili. It was renamed in 1961 when Tanzania gained independence from British rule.',
                     category: 'history',
                 },
                 {
-                    id: 'kili-7-2',
+                    id: 'kili-6-2',
                     content: 'At the summit, there\'s about 50% less oxygen than at sea level. Your body is working twice as hard just to breathe!',
                     category: 'science',
                 },
                 {
-                    id: 'kili-7-3',
+                    id: 'kili-6-3',
                     content: 'The oldest person to summit Kilimanjaro was Anne Lorimor at age 89 in 2019!',
                     category: 'adventure',
                     source: 'Guinness World Records',
@@ -211,7 +223,7 @@ const FUN_FACTS_DATA: Record<string, Record<number, {
             ],
             historicalSites: [
                 {
-                    id: 'kili-hist-7-1',
+                    id: 'kili-hist-6-1',
                     name: 'Uhuru Peak',
                     coordinates: [37.3556, -3.0758],
                     summary: 'The highest point in Africa at 5,895m. Named for Tanzanian independence in 1961.',
@@ -226,7 +238,7 @@ const FUN_FACTS_DATA: Record<string, Record<number, {
             ],
             pointsOfInterest: [
                 {
-                    id: 'kili-poi-7-1',
+                    id: 'kili-poi-6-1',
                     name: 'Stella Point',
                     category: 'summit',
                     coordinates: [37.3512, -3.0789],
@@ -234,31 +246,424 @@ const FUN_FACTS_DATA: Record<string, Record<number, {
                     description: 'The crater rim point where most climbers reach at sunrise. Just 1 more hour to Uhuru!',
                 },
                 {
-                    id: 'kili-poi-7-2',
+                    id: 'kili-poi-6-2',
                     name: 'Furtwängler Glacier',
                     category: 'landmark',
                     coordinates: [37.3534, -3.0756],
                     elevation: 5800,
-                    description: 'One of the last remaining glaciers near the summit, named after German climber Walter Furtwängler.',
+                    description: 'One of the last remaining glaciers near the summit, named after German climber Walter Furtwängler who summited in 1912.',
                 },
             ],
         },
-        8: {
+        'Mweka Camp': {
             funFacts: [
                 {
-                    id: 'kili-8-1',
-                    content: 'The descent from summit to Mweka Gate covers over 3,700m of elevation loss in just one day - be kind to your knees!',
-                    category: 'survival',
+                    id: 'kili-6-4',
+                    content: 'The descent from summit to Mweka Camp covers over 2,800m of elevation loss - more than the height of the Swiss Alps from base to peak!',
+                    category: 'adventure',
                 },
                 {
-                    id: 'kili-8-2',
+                    id: 'kili-6-5',
+                    content: 'Your porters carry up to 20kg each and make this journey multiple times per month. Many are from the local Chagga tribe.',
+                    category: 'culture',
+                },
+            ],
+        },
+        'Mweka Gate (Finish)': {
+            funFacts: [
+                {
+                    id: 'kili-7-1',
                     content: 'You\'ll receive an official summit certificate at the gate - green for reaching Stella Point (5,756m), gold for Uhuru Peak (5,895m).',
                     category: 'adventure',
+                },
+                {
+                    id: 'kili-7-2',
+                    content: 'The Chagga people who live on Kilimanjaro\'s slopes have farmed its fertile volcanic soil for over 500 years, growing coffee and bananas.',
+                    category: 'culture',
                 },
             ],
         },
     },
-    // Add more journeys here...
+
+    // ============================================
+    // INCA TRAIL TO MACHU PICCHU (4 days)
+    // ============================================
+    'inca-trail': {
+        'Wayllabamba Camp': {
+            funFacts: [
+                {
+                    id: 'inca-1-1',
+                    content: 'Wayllabamba means "grassy plain" in Quechua. Much of the village is built on original Inca foundations - a living museum of indigenous culture.',
+                    category: 'culture',
+                    source: 'Peru Ministry of Culture',
+                },
+                {
+                    id: 'inca-1-2',
+                    content: 'The first archaeological site you passed, Llactapata (Patallacta), has 112 rooms and was burned by Manco Inca in 1536 to discourage Spanish pursuit.',
+                    category: 'history',
+                },
+                {
+                    id: 'inca-1-3',
+                    content: 'Giant hummingbirds (Patagona gigas), the largest hummingbird species at over 18cm, are commonly seen near Patallacta.',
+                    category: 'wildlife',
+                },
+            ],
+            pointsOfInterest: [
+                {
+                    id: 'inca-poi-1-1',
+                    name: 'Llactapata/Patallacta Ruins',
+                    category: 'landmark',
+                    coordinates: [-72.52, -13.22],
+                    elevation: 2750,
+                    description: 'First major Inca site with 112 rooms. Served as a control point for agricultural products along the royal Inca road network.',
+                },
+            ],
+            historicalSites: [
+                {
+                    id: 'inca-hist-1-1',
+                    name: 'Patallacta',
+                    coordinates: [-72.52, -13.22],
+                    summary: 'Agricultural redistribution center with 112 rooms, burned by Manco Inca in 1536.',
+                    description: 'This archaeological site comprises rooms built with rustic and carved stones. The agricultural sector measures 600 by 150 meters, divided into 25 levels of terraces.',
+                    period: '15th century - 1536',
+                    significance: 'notable',
+                    tags: ['agriculture', 'Inca', 'terraces'],
+                },
+            ],
+        },
+        'Pacaymayo Camp': {
+            funFacts: [
+                {
+                    id: 'inca-2-1',
+                    content: 'Dead Woman\'s Pass (Warmiwañusca) at 4,215m is the highest point on the Inca Trail - nearly 1,800m higher than Machu Picchu itself!',
+                    category: 'adventure',
+                    source: 'National Geographic',
+                },
+                {
+                    id: 'inca-2-2',
+                    content: '"Warmiwañusca" combines Quechua words for "woman" (warmi) and "dead" (wañusca). The mountain\'s profile resembles a supine woman when viewed from the valley.',
+                    category: 'culture',
+                },
+                {
+                    id: 'inca-2-3',
+                    content: 'Polylepis (Queñua) trees with distinctive red peeling bark are the highest-growing trees in the world, surviving above 5,000m in these Andean forests.',
+                    category: 'flora',
+                },
+                {
+                    id: 'inca-2-4',
+                    content: 'Vizcachas, resembling large rabbits with long tails and related to chinchillas, are commonly seen sunbathing on rocks near the pass.',
+                    category: 'wildlife',
+                },
+            ],
+            pointsOfInterest: [
+                {
+                    id: 'inca-poi-2-1',
+                    name: 'Dead Woman\'s Pass (Warmiwañusca)',
+                    category: 'summit',
+                    coordinates: [-72.52, -13.20],
+                    elevation: 4215,
+                    description: 'The highest point on the Inca Trail. 1,200m elevation gain from Wayllabamba in a single day.',
+                    tips: ['Start early to avoid afternoon weather', 'Take it slow - altitude affects everyone'],
+                },
+            ],
+        },
+        'Wiñay Wayna Camp': {
+            funFacts: [
+                {
+                    id: 'inca-3-1',
+                    content: 'Day 3 is the most archaeologically rich section - you passed four major Inca sites: Runkurakay, Sayacmarca, Phuyupatamarca, and Wiñay Wayna.',
+                    category: 'history',
+                },
+                {
+                    id: 'inca-3-2',
+                    content: '"Wiñay Wayna" means "Forever Young" in Quechua, named after an orchid that was used as a military emblem by Inca warriors.',
+                    category: 'culture',
+                },
+                {
+                    id: 'inca-3-3',
+                    content: 'Phuyupatamarca ("City Above the Clouds") has 5 ceremonial stone baths fed by underground channels that are still flowing today after 500+ years!',
+                    category: 'history',
+                    source: 'UNESCO',
+                },
+                {
+                    id: 'inca-3-4',
+                    content: 'The Cock-of-the-Rock (Rupícola peruviana), Peru\'s vibrant orange national bird, can be spotted on mountain cliffs in this cloud forest zone.',
+                    category: 'wildlife',
+                },
+                {
+                    id: 'inca-3-5',
+                    content: 'Over 400 orchid species thrive along the Inca Trail, including the endemic "Golden Angel Orchid" (Masdevallia veitchiana).',
+                    category: 'flora',
+                },
+            ],
+            pointsOfInterest: [
+                {
+                    id: 'inca-poi-3-1',
+                    name: 'Runkurakay',
+                    category: 'landmark',
+                    coordinates: [-72.51, -13.19],
+                    elevation: 3850,
+                    description: 'A tambo (rest station) for chasquis (Inca messengers). Features unusual circular enclosures rare in Inca architecture.',
+                },
+                {
+                    id: 'inca-poi-3-2',
+                    name: 'Sayacmarca',
+                    category: 'landmark',
+                    coordinates: [-72.5169, -13.2281],
+                    elevation: 3600,
+                    description: '"Inaccessible Town" - accessed by climbing 98 vertical stone steps. Discovered by Hiram Bingham in 1915.',
+                },
+                {
+                    id: 'inca-poi-3-3',
+                    name: 'Phuyupatamarca',
+                    category: 'landmark',
+                    coordinates: [-72.5317, -13.2064],
+                    elevation: 3650,
+                    description: '"City Above the Clouds" with 5 ceremonial baths fed by underground channels still flowing after 500+ years.',
+                },
+            ],
+            historicalSites: [
+                {
+                    id: 'inca-hist-3-1',
+                    name: 'Wiñay Wayna Ruins',
+                    coordinates: [-72.5352, -13.1890],
+                    summary: 'Best preserved ruins before Machu Picchu, with dramatic terraces and water fountains for ritual cleansing.',
+                    description: 'Built under Emperor Pachacutec in the mid-15th century. Rediscovered by explorer Paul Fejos in 1941. Features agricultural terraces cascading down the hillside.',
+                    period: '15th century',
+                    significance: 'major',
+                    tags: ['terraces', 'fountains', 'Pachacutec'],
+                    links: [
+                        { label: 'Wikipedia', url: 'https://en.wikipedia.org/wiki/Winay_Wayna' },
+                    ],
+                },
+            ],
+        },
+        'Machu Picchu (Sun Gate)': {
+            funFacts: [
+                {
+                    id: 'inca-4-1',
+                    content: 'Intipunku (Sun Gate) was the main checkpoint for pilgrims entering Machu Picchu. It\'s aligned to frame the sunrise on the winter solstice (June 21).',
+                    category: 'history',
+                    source: 'UNESCO World Heritage',
+                },
+                {
+                    id: 'inca-4-2',
+                    content: 'The Inca Trail is part of the Qhapaq Ñan, a 40,000 km road network spanning 6 countries - declared UNESCO World Heritage in 2014.',
+                    category: 'history',
+                    source: 'UNESCO',
+                    learn_more_url: 'https://whc.unesco.org/en/list/1459',
+                },
+                {
+                    id: 'inca-4-3',
+                    content: 'Chasquis (Inca messengers) could relay a message 240km in a single day using relay stations (tambos) like the ones you passed on the trail.',
+                    category: 'history',
+                },
+                {
+                    id: 'inca-4-4',
+                    content: 'The spectacled bear (Tremarctos ornatus), South America\'s only bear species, inhabits the surrounding cloud forest. Called "ukuku" in Quechua.',
+                    category: 'wildlife',
+                },
+            ],
+            pointsOfInterest: [
+                {
+                    id: 'inca-poi-4-1',
+                    name: 'Intipunku (Sun Gate)',
+                    category: 'viewpoint',
+                    coordinates: [-72.538, -13.159],
+                    elevation: 2745,
+                    description: 'The iconic first view of Machu Picchu. Aligned for the winter solstice sunrise on June 21.',
+                    tips: ['Arrive early for the classic misty view', 'Best photos in early morning light'],
+                },
+            ],
+            historicalSites: [
+                {
+                    id: 'inca-hist-4-1',
+                    name: 'Machu Picchu',
+                    coordinates: [-72.5450, -13.1631],
+                    summary: 'UNESCO World Heritage Site - the "Lost City of the Incas" built by Emperor Pachacutec around 1450.',
+                    description: 'One of the New Seven Wonders of the World. The citadel was never found by Spanish conquistadors and remained unknown to the outside world until Hiram Bingham\'s expedition in 1911.',
+                    period: '1450 - 1572',
+                    significance: 'major',
+                    tags: ['UNESCO', 'Wonder of the World', 'Pachacutec'],
+                    links: [
+                        { label: 'UNESCO', url: 'https://whc.unesco.org/en/list/274' },
+                        { label: 'Wikipedia', url: 'https://en.wikipedia.org/wiki/Machu_Picchu' },
+                    ],
+                },
+            ],
+        },
+    },
+
+    // ============================================
+    // MOUNT KENYA - CHOGORIA/SIRIMON (5 days)
+    // ============================================
+    'mount-kenya': {
+        'Special Camp': {
+            funFacts: [
+                {
+                    id: 'kenya-1-1',
+                    content: 'Mount Kenya is an extinct stratovolcano that formed 2.6-3.1 million years ago. At its peak, it may have exceeded 7,000m - taller than Kilimanjaro today!',
+                    category: 'geology',
+                    source: 'UNESCO World Heritage',
+                },
+                {
+                    id: 'kenya-1-2',
+                    content: 'Mount Kenya is called "Kirinyaga" (Mountain of Whiteness) by the Kikuyu people. It\'s considered the home of Ngai, the creator God.',
+                    category: 'culture',
+                },
+                {
+                    id: 'kenya-1-3',
+                    content: 'The bamboo zone you passed through features Oldeania alpina bamboo growing up to 15 meters tall. Natural pathways are kept open by elephants and buffalo!',
+                    category: 'flora',
+                },
+            ],
+            pointsOfInterest: [
+                {
+                    id: 'kenya-poi-1-1',
+                    name: 'Chogoria Gate',
+                    category: 'info',
+                    coordinates: [37.52, -0.17],
+                    elevation: 2950,
+                    description: 'The scenic eastern entrance to Mount Kenya National Park on the Chogoria route.',
+                },
+            ],
+        },
+        'Lake Ellis Camp': {
+            funFacts: [
+                {
+                    id: 'kenya-2-1',
+                    content: 'Mount Kenya has 12 remnant glaciers, all receding rapidly. The Lewis Glacier has lost 90% of its volume since 1934 and may disappear by 2030.',
+                    category: 'climate',
+                    source: 'UNEP',
+                },
+                {
+                    id: 'kenya-2-2',
+                    content: 'The Mount Kenya hyrax (rock hyrax) is common here. Despite looking like a rodent, it\'s actually more closely related to elephants and manatees!',
+                    category: 'wildlife',
+                },
+                {
+                    id: 'kenya-2-3',
+                    content: 'The lower alpine zone features high tussock-grass moorland with waist-high Festuca pilgeri grasses adapted to extreme temperature swings.',
+                    category: 'flora',
+                },
+            ],
+            pointsOfInterest: [
+                {
+                    id: 'kenya-poi-2-1',
+                    name: 'Lake Ellis',
+                    category: 'landmark',
+                    coordinates: [37.38, -0.12],
+                    elevation: 3466,
+                    description: 'A beautiful alpine lake marking the transition into the afroalpine zone. Critical acclimatization stop on the Chogoria route.',
+                },
+            ],
+        },
+        'Lake Michaelson Camp': {
+            funFacts: [
+                {
+                    id: 'kenya-3-1',
+                    content: 'Lake Michaelson sits in the dramatic Gorges Valley surrounded by 200-300m vertical cliffs. It was named by Halford Mackinder during the first ascent in 1899.',
+                    category: 'geology',
+                },
+                {
+                    id: 'kenya-3-2',
+                    content: 'Giant groundsels (Dendrosenecio keniodendron) can reach 10 meters tall here - prehistoric plants adapted to freezing nights and intense UV radiation.',
+                    category: 'flora',
+                },
+                {
+                    id: 'kenya-3-3',
+                    content: 'Vivienne Falls, visible from the valley, is Kenya\'s tallest waterfall at 457m (1,500 ft) - the 5th tallest in Africa!',
+                    category: 'geology',
+                },
+                {
+                    id: 'kenya-3-4',
+                    content: 'The scarlet-tufted malachite sunbird, endemic to East African alpine zones, feeds almost exclusively on Lobelia telekii nectar at this elevation.',
+                    category: 'wildlife',
+                },
+            ],
+            pointsOfInterest: [
+                {
+                    id: 'kenya-poi-3-1',
+                    name: 'Lake Michaelson',
+                    category: 'landmark',
+                    coordinates: [37.32, -0.13],
+                    elevation: 3961,
+                    description: 'A stunning 30-acre lake feeding the Nithi River, surrounded by towering cliffs and considered the most beautiful spot on Mount Kenya.',
+                },
+                {
+                    id: 'kenya-poi-3-2',
+                    name: 'Gorges Valley',
+                    category: 'viewpoint',
+                    coordinates: [37.31, -0.14],
+                    elevation: 4000,
+                    description: 'Dramatic U-shaped glacial valley with 300m vertical cliffs, including "The Temple" buttress.',
+                },
+                {
+                    id: 'kenya-poi-3-3',
+                    name: 'Vivienne Falls',
+                    category: 'landmark',
+                    coordinates: [37.30, -0.12],
+                    elevation: 3984,
+                    description: 'Kenya\'s tallest waterfall at 457m. Named after British adventurer Vivienne de Watteville who explored Mount Kenya in 1928-29.',
+                },
+            ],
+        },
+        'Sirimon Gate (Finish)': {
+            funFacts: [
+                {
+                    id: 'kenya-4-1',
+                    content: 'In 1899, Halford Mackinder led a caravan of 176 people to make the first successful ascent of Mount Kenya\'s Batian peak with Italian guides César Ollier and Joseph Brocherel.',
+                    category: 'history',
+                },
+                {
+                    id: 'kenya-4-2',
+                    content: 'Mount Kenya\'s three highest peaks are named after Maasai laibons (spiritual leaders): Batian (5,199m), Nelion (5,188m), and Point Lenana (4,985m).',
+                    category: 'history',
+                },
+                {
+                    id: 'kenya-4-3',
+                    content: 'Mount Kenya was designated a UNESCO Biosphere Reserve in 1978 and World Heritage Site in 1997, recognizing its outstanding natural value.',
+                    category: 'history',
+                    source: 'UNESCO',
+                },
+            ],
+            historicalSites: [
+                {
+                    id: 'kenya-hist-4-1',
+                    name: 'Mount Kenya National Park',
+                    coordinates: [37.35, -0.15],
+                    summary: 'UNESCO World Heritage Site established in 1949, protecting Africa\'s second-highest mountain and its unique ecosystems.',
+                    description: 'The park covers 715 square kilometers and hosts an estimated 5,000 plant and animal species. The afroalpine vegetation is among the rarest ecosystems on the African continent.',
+                    period: '1949 - Present',
+                    significance: 'major',
+                    tags: ['UNESCO', 'biodiversity', 'conservation'],
+                    links: [
+                        { label: 'UNESCO', url: 'https://whc.unesco.org/en/list/800/' },
+                    ],
+                },
+            ],
+        },
+        'Safari: Saruni Basecamp': {
+            funFacts: [
+                {
+                    id: 'kenya-5-1',
+                    content: 'The Laikipia/Samburu region offers the "Samburu Special Five" - species unique to northern Kenya: Grevy\'s zebra, reticulated giraffe, Beisa oryx, Somali ostrich, and the elegant gerenuk.',
+                    category: 'wildlife',
+                },
+                {
+                    id: 'kenya-5-2',
+                    content: 'Mount Kenya serves as a critical water tower for millions of Kenyans. As glaciers recede, rivers are becoming less predictable - elders report snow coverage that was extensive in the 1960s is now almost gone.',
+                    category: 'climate',
+                    source: 'UNEP',
+                },
+                {
+                    id: 'kenya-5-3',
+                    content: 'Saruni community conservancies maintain higher wildlife densities than many national parks while providing income directly to local Samburu landowners.',
+                    category: 'culture',
+                },
+            ],
+        },
+    },
 };
 
 interface WaypointWithJourney {
@@ -320,10 +725,11 @@ async function main() {
             continue;
         }
 
-        const dayData = journeyData[waypoint.day_number];
+        // Look up by waypoint name instead of day number
+        const waypointData = journeyData[waypoint.name];
 
-        if (!dayData) {
-            console.log(`⏭️  ${journey.name} Day ${waypoint.day_number}: No data for this day`);
+        if (!waypointData) {
+            console.log(`⏭️  ${journey.name} Day ${waypoint.day_number}: ${waypoint.name} (no data configured)`);
             skipped++;
             continue;
         }
@@ -343,19 +749,19 @@ async function main() {
 
         const updateData: Record<string, unknown> = {};
 
-        if (dayData.funFacts && !hasFunFacts) {
-            updateData.fun_facts = dayData.funFacts;
-            console.log(`   💡 Adding ${dayData.funFacts.length} fun facts`);
+        if (waypointData.funFacts && !hasFunFacts) {
+            updateData.fun_facts = waypointData.funFacts;
+            console.log(`   💡 Adding ${waypointData.funFacts.length} fun facts`);
         }
 
-        if (dayData.pointsOfInterest && !hasPOIs) {
-            updateData.points_of_interest = dayData.pointsOfInterest;
-            console.log(`   📍 Adding ${dayData.pointsOfInterest.length} points of interest`);
+        if (waypointData.pointsOfInterest && !hasPOIs) {
+            updateData.points_of_interest = waypointData.pointsOfInterest;
+            console.log(`   📍 Adding ${waypointData.pointsOfInterest.length} points of interest`);
         }
 
-        if (dayData.historicalSites && !hasHistoricalSites) {
-            updateData.historical_sites = dayData.historicalSites;
-            console.log(`   🏛️ Adding ${dayData.historicalSites.length} historical sites`);
+        if (waypointData.historicalSites && !hasHistoricalSites) {
+            updateData.historical_sites = waypointData.historicalSites;
+            console.log(`   🏛️ Adding ${waypointData.historicalSites.length} historical sites`);
         }
 
         if (Object.keys(updateData).length === 0) {

--- a/src/components/journey/DayChapter.tsx
+++ b/src/components/journey/DayChapter.tsx
@@ -6,12 +6,16 @@
  * - Day header (day number, date, camp name, elevation)
  * - Photo strip (horizontal scroll)
  * - Description and highlights
+ * - Fun facts for the day
+ * - Points of interest and historical sites
  */
 
 import { memo, useMemo } from 'react';
 import type { Camp, Photo } from '../../types/trek';
 import { colors, radius } from '../../styles/liquidGlass';
 import { PhotoStrip } from './PhotoStrip';
+import { FunFactCard } from './FunFactCard';
+import { DayDiscoveries } from './DayDiscoveries';
 
 interface DayChapterProps {
     camp: Camp;
@@ -220,7 +224,7 @@ export const DayChapter = memo(function DayChapter({
                 {camp.highlights && camp.highlights.length > 0 && (
                     <ul style={{
                         margin: 0,
-                        marginBottom: stripPhotos.length > 0 ? 12 : 0,
+                        marginBottom: 12,
                         paddingLeft: 18,
                     }}>
                         {camp.highlights.map((highlight, idx) => (
@@ -238,21 +242,61 @@ export const DayChapter = memo(function DayChapter({
                     </ul>
                 )}
 
+                {/* Fun Facts */}
+                {camp.funFacts && camp.funFacts.length > 0 && (
+                    <div style={{ marginBottom: 12 }}>
+                        <div
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 6,
+                                marginBottom: 10,
+                            }}
+                        >
+                            <span style={{ fontSize: 14 }}>💡</span>
+                            <span
+                                style={{
+                                    fontSize: 11,
+                                    fontWeight: 600,
+                                    textTransform: 'uppercase',
+                                    letterSpacing: '0.08em',
+                                    color: colors.text.tertiary,
+                                }}
+                            >
+                                Did you know?
+                            </span>
+                        </div>
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                            {camp.funFacts.map((fact) => (
+                                <FunFactCard key={fact.id} fact={fact} compact />
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {/* Points of Interest & Historical Sites */}
+                <DayDiscoveries
+                    pointsOfInterest={camp.pointsOfInterest}
+                    historicalSites={camp.historicalSites}
+                />
+
                 {/* Photo strip */}
                 {stripPhotos.length > 0 && (
-                    <PhotoStrip
-                        photos={stripPhotos}
-                        getMediaUrl={getMediaUrl}
-                        onPhotoClick={(photo, idx) => {
-                            // Adjust index to account for hero photo
-                            const actualIndex = heroPhoto ? idx + 1 : idx;
-                            onPhotoClick(photo, actualIndex);
-                        }}
-                    />
+                    <div style={{ marginTop: 12 }}>
+                        <PhotoStrip
+                            photos={stripPhotos}
+                            getMediaUrl={getMediaUrl}
+                            onPhotoClick={(photo, idx) => {
+                                // Adjust index to account for hero photo
+                                const actualIndex = heroPhoto ? idx + 1 : idx;
+                                onPhotoClick(photo, actualIndex);
+                            }}
+                        />
+                    </div>
                 )}
 
                 {/* No photos state */}
-                {photos.length === 0 && (
+                {photos.length === 0 && !camp.funFacts?.length && !camp.pointsOfInterest?.length && !camp.historicalSites?.length && (
                     <div style={{
                         padding: '20px 0',
                         textAlign: 'center',

--- a/src/components/journey/DayDiscoveries.tsx
+++ b/src/components/journey/DayDiscoveries.tsx
@@ -1,0 +1,416 @@
+/**
+ * DayDiscoveries - Points of Interest and Historical Sites for a day
+ *
+ * Expandable section showing notable locations encountered during the day's trek
+ */
+
+import { memo, useState } from 'react';
+import type { PointOfInterest, HistoricalSite, POICategory } from '../../types/trek';
+import { colors, radius } from '../../styles/liquidGlass';
+
+interface DayDiscoveriesProps {
+    pointsOfInterest?: PointOfInterest[];
+    historicalSites?: HistoricalSite[];
+}
+
+/** POI category icons and colors */
+const POI_CONFIG: Record<POICategory, { icon: string; color: string }> = {
+    viewpoint: { icon: '👁️', color: '#60a5fa' },
+    water: { icon: '💧', color: '#38bdf8' },
+    landmark: { icon: '🏛️', color: '#f59e0b' },
+    shelter: { icon: '🏕️', color: '#a78bfa' },
+    warning: { icon: '⚠️', color: '#ef4444' },
+    info: { icon: 'ℹ️', color: '#8b5cf6' },
+    wildlife: { icon: '🦒', color: '#fbbf24' },
+    photo_spot: { icon: '📸', color: '#f472b6' },
+    rest_area: { icon: '🪑', color: '#34d399' },
+    summit: { icon: '⛰️', color: '#ef4444' },
+};
+
+/** Significance colors for historical sites */
+const SIGNIFICANCE_COLORS = {
+    major: '#f59e0b',
+    notable: '#60a5fa',
+    minor: 'rgba(255,255,255,0.4)',
+} as const;
+
+interface ExpandableCardProps {
+    title: string;
+    subtitle?: string;
+    icon: string;
+    color: string;
+    children: React.ReactNode;
+    defaultExpanded?: boolean;
+}
+
+const ExpandableCard = memo(function ExpandableCard({
+    title,
+    subtitle,
+    icon,
+    color,
+    children,
+    defaultExpanded = false,
+}: ExpandableCardProps) {
+    const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+    return (
+        <div
+            style={{
+                background: 'rgba(255, 255, 255, 0.04)',
+                borderRadius: radius.sm,
+                overflow: 'hidden',
+                marginBottom: 8,
+            }}
+        >
+            <button
+                onClick={() => setIsExpanded(!isExpanded)}
+                style={{
+                    width: '100%',
+                    padding: '10px 12px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 10,
+                    background: 'transparent',
+                    border: 'none',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                }}
+            >
+                <span
+                    style={{
+                        fontSize: 16,
+                        width: 28,
+                        height: 28,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        background: `${color}20`,
+                        borderRadius: 6,
+                        flexShrink: 0,
+                    }}
+                >
+                    {icon}
+                </span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                    <span
+                        style={{
+                            fontSize: 13,
+                            fontWeight: 500,
+                            color: colors.text.primary,
+                            display: 'block',
+                        }}
+                    >
+                        {title}
+                    </span>
+                    {subtitle && (
+                        <span
+                            style={{
+                                fontSize: 11,
+                                color: colors.text.subtle,
+                            }}
+                        >
+                            {subtitle}
+                        </span>
+                    )}
+                </div>
+                <span
+                    style={{
+                        fontSize: 12,
+                        color: colors.text.subtle,
+                        transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                        transition: 'transform 0.2s',
+                    }}
+                >
+                    ▼
+                </span>
+            </button>
+
+            {isExpanded && (
+                <div
+                    style={{
+                        padding: '0 12px 12px',
+                        borderTop: `1px solid ${colors.glass.borderSubtle}`,
+                    }}
+                >
+                    {children}
+                </div>
+            )}
+        </div>
+    );
+});
+
+const POICard = memo(function POICard({ poi }: { poi: PointOfInterest }) {
+    const config = POI_CONFIG[poi.category] || POI_CONFIG.landmark;
+    const icon = poi.icon || config.icon;
+
+    return (
+        <ExpandableCard
+            title={poi.name}
+            subtitle={poi.elevation ? `${poi.elevation}m` : undefined}
+            icon={icon}
+            color={config.color}
+        >
+            {poi.description && (
+                <p
+                    style={{
+                        fontSize: 13,
+                        lineHeight: 1.5,
+                        color: colors.text.secondary,
+                        margin: '10px 0 0',
+                    }}
+                >
+                    {poi.description}
+                </p>
+            )}
+            {poi.tips && poi.tips.length > 0 && (
+                <div style={{ marginTop: 10 }}>
+                    <span
+                        style={{
+                            fontSize: 10,
+                            fontWeight: 600,
+                            textTransform: 'uppercase',
+                            letterSpacing: '0.05em',
+                            color: colors.text.subtle,
+                        }}
+                    >
+                        Tips
+                    </span>
+                    <ul
+                        style={{
+                            margin: '6px 0 0',
+                            paddingLeft: 16,
+                        }}
+                    >
+                        {poi.tips.map((tip, idx) => (
+                            <li
+                                key={idx}
+                                style={{
+                                    fontSize: 12,
+                                    color: colors.text.tertiary,
+                                    marginBottom: 4,
+                                }}
+                            >
+                                {tip}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+            {poi.timeFromPrevious && (
+                <div
+                    style={{
+                        marginTop: 8,
+                        fontSize: 11,
+                        color: colors.text.subtle,
+                    }}
+                >
+                    ⏱ {poi.timeFromPrevious} from previous stop
+                </div>
+            )}
+        </ExpandableCard>
+    );
+});
+
+const HistoricalSiteCard = memo(function HistoricalSiteCard({ site }: { site: HistoricalSite }) {
+    const significanceColor = SIGNIFICANCE_COLORS[site.significance || 'minor'];
+
+    return (
+        <ExpandableCard
+            title={site.name}
+            subtitle={site.period}
+            icon="🏛️"
+            color={significanceColor}
+        >
+            <p
+                style={{
+                    fontSize: 13,
+                    lineHeight: 1.5,
+                    color: colors.text.secondary,
+                    margin: '10px 0 0',
+                }}
+            >
+                {site.summary}
+            </p>
+
+            {site.description && (
+                <p
+                    style={{
+                        fontSize: 13,
+                        lineHeight: 1.6,
+                        color: colors.text.tertiary,
+                        margin: '10px 0 0',
+                        paddingTop: 10,
+                        borderTop: `1px solid ${colors.glass.borderSubtle}`,
+                    }}
+                >
+                    {site.description}
+                </p>
+            )}
+
+            {site.tags && site.tags.length > 0 && (
+                <div
+                    style={{
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        gap: 6,
+                        marginTop: 10,
+                    }}
+                >
+                    {site.tags.map((tag) => (
+                        <span
+                            key={tag}
+                            style={{
+                                padding: '3px 8px',
+                                background: 'rgba(96, 165, 250, 0.15)',
+                                borderRadius: 4,
+                                fontSize: 10,
+                                color: colors.accent.primary,
+                            }}
+                        >
+                            {tag}
+                        </span>
+                    ))}
+                </div>
+            )}
+
+            {site.links && site.links.length > 0 && (
+                <div style={{ marginTop: 10 }}>
+                    {site.links.map((link) => (
+                        <a
+                            key={link.url}
+                            href={link.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={(e) => e.stopPropagation()}
+                            style={{
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                gap: 4,
+                                marginRight: 12,
+                                fontSize: 12,
+                                color: colors.accent.primary,
+                                textDecoration: 'none',
+                            }}
+                        >
+                            {link.label}
+                            <span style={{ fontSize: 10 }}>→</span>
+                        </a>
+                    ))}
+                </div>
+            )}
+        </ExpandableCard>
+    );
+});
+
+export const DayDiscoveries = memo(function DayDiscoveries({
+    pointsOfInterest = [],
+    historicalSites = [],
+}: DayDiscoveriesProps) {
+    const hasPOIs = pointsOfInterest.length > 0;
+    const hasHistoricalSites = historicalSites.length > 0;
+
+    if (!hasPOIs && !hasHistoricalSites) {
+        return null;
+    }
+
+    return (
+        <div style={{ marginTop: 12 }}>
+            {/* Section Header */}
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    marginBottom: 10,
+                }}
+            >
+                <span style={{ fontSize: 14 }}>🔍</span>
+                <span
+                    style={{
+                        fontSize: 11,
+                        fontWeight: 600,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.08em',
+                        color: colors.text.tertiary,
+                    }}
+                >
+                    Discoveries
+                </span>
+                <span
+                    style={{
+                        marginLeft: 'auto',
+                        padding: '2px 8px',
+                        background: 'rgba(96, 165, 250, 0.15)',
+                        borderRadius: 10,
+                        fontSize: 10,
+                        color: colors.accent.primary,
+                    }}
+                >
+                    {pointsOfInterest.length + historicalSites.length} places
+                </span>
+            </div>
+
+            {/* Historical Sites */}
+            {hasHistoricalSites && (
+                <div style={{ marginBottom: hasPOIs ? 12 : 0 }}>
+                    <div
+                        style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 6,
+                            marginBottom: 8,
+                        }}
+                    >
+                        <span style={{ color: '#f59e0b', fontSize: 12 }}>★</span>
+                        <span
+                            style={{
+                                fontSize: 10,
+                                fontWeight: 500,
+                                color: colors.text.subtle,
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.05em',
+                            }}
+                        >
+                            Historical Sites
+                        </span>
+                    </div>
+                    {historicalSites.map((site) => (
+                        <HistoricalSiteCard key={site.id} site={site} />
+                    ))}
+                </div>
+            )}
+
+            {/* Points of Interest */}
+            {hasPOIs && (
+                <div>
+                    <div
+                        style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 6,
+                            marginBottom: 8,
+                        }}
+                    >
+                        <span style={{ fontSize: 12 }}>📍</span>
+                        <span
+                            style={{
+                                fontSize: 10,
+                                fontWeight: 500,
+                                color: colors.text.subtle,
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.05em',
+                            }}
+                        >
+                            Points of Interest
+                        </span>
+                    </div>
+                    {pointsOfInterest.map((poi) => (
+                        <POICard key={poi.id} poi={poi} />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+});
+
+export default DayDiscoveries;

--- a/src/components/journey/FunFactCard.tsx
+++ b/src/components/journey/FunFactCard.tsx
@@ -1,0 +1,165 @@
+/**
+ * FunFactCard - Display interesting facts about the journey day
+ *
+ * Shows educational trivia with category icons and optional "learn more" links
+ */
+
+import { memo } from 'react';
+import type { FunFact, FunFactCategory } from '../../types/trek';
+import { colors, radius } from '../../styles/liquidGlass';
+
+interface FunFactCardProps {
+    fact: FunFact;
+    compact?: boolean;
+}
+
+/** Category icons and colors */
+const CATEGORY_CONFIG: Record<FunFactCategory, { icon: string; color: string; label: string }> = {
+    geology: { icon: '🪨', color: '#a78bfa', label: 'Geology' },
+    wildlife: { icon: '🦁', color: '#fbbf24', label: 'Wildlife' },
+    flora: { icon: '🌿', color: '#34d399', label: 'Flora' },
+    history: { icon: '📜', color: '#f59e0b', label: 'History' },
+    culture: { icon: '🎭', color: '#f472b6', label: 'Culture' },
+    climate: { icon: '🌤️', color: '#60a5fa', label: 'Climate' },
+    adventure: { icon: '⛰️', color: '#ef4444', label: 'Adventure' },
+    science: { icon: '🔬', color: '#8b5cf6', label: 'Science' },
+    geography: { icon: '🗺️', color: '#14b8a6', label: 'Geography' },
+    survival: { icon: '🧭', color: '#f97316', label: 'Survival' },
+};
+
+export const FunFactCard = memo(function FunFactCard({ fact, compact = false }: FunFactCardProps) {
+    const config = CATEGORY_CONFIG[fact.category] || CATEGORY_CONFIG.geography;
+    const icon = fact.icon || config.icon;
+
+    if (compact) {
+        return (
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: 10,
+                    padding: '10px 12px',
+                    background: 'rgba(255, 255, 255, 0.04)',
+                    borderRadius: radius.sm,
+                    borderLeft: `3px solid ${config.color}`,
+                }}
+            >
+                <span style={{ fontSize: 16, flexShrink: 0 }}>{icon}</span>
+                <p
+                    style={{
+                        fontSize: 13,
+                        lineHeight: 1.5,
+                        color: colors.text.secondary,
+                        margin: 0,
+                    }}
+                >
+                    {fact.content}
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div
+            style={{
+                padding: 14,
+                background: `linear-gradient(135deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0.02) 100%)`,
+                borderRadius: radius.md,
+                border: `1px solid ${colors.glass.borderSubtle}`,
+            }}
+        >
+            {/* Header */}
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    marginBottom: 10,
+                }}
+            >
+                <span
+                    style={{
+                        fontSize: 20,
+                        width: 32,
+                        height: 32,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        background: `${config.color}20`,
+                        borderRadius: radius.sm,
+                    }}
+                >
+                    {icon}
+                </span>
+                <span
+                    style={{
+                        fontSize: 10,
+                        fontWeight: 600,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.08em',
+                        color: config.color,
+                    }}
+                >
+                    {config.label}
+                </span>
+            </div>
+
+            {/* Content */}
+            <p
+                style={{
+                    fontSize: 14,
+                    lineHeight: 1.6,
+                    color: colors.text.secondary,
+                    margin: 0,
+                }}
+            >
+                {fact.content}
+            </p>
+
+            {/* Source & Learn More */}
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    marginTop: 12,
+                    paddingTop: 10,
+                    borderTop: `1px solid ${colors.glass.borderSubtle}`,
+                }}
+            >
+                {fact.source && (
+                    <span
+                        style={{
+                            fontSize: 11,
+                            color: colors.text.subtle,
+                            fontStyle: 'italic',
+                        }}
+                    >
+                        Source: {fact.source}
+                    </span>
+                )}
+                {fact.learnMoreUrl && (
+                    <a
+                        href={fact.learnMoreUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        style={{
+                            fontSize: 12,
+                            color: colors.accent.primary,
+                            textDecoration: 'none',
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 4,
+                        }}
+                    >
+                        Learn more
+                        <span style={{ fontSize: 10 }}>→</span>
+                    </a>
+                )}
+            </div>
+        </div>
+    );
+});
+
+export default FunFactCard;

--- a/src/components/layout/BottomSheetContent.tsx
+++ b/src/components/layout/BottomSheetContent.tsx
@@ -23,6 +23,8 @@ import { WaypointEditModal } from '../trek/WaypointEditModal';
 import { PhotoAssignModal } from '../trek/PhotoAssignModal';
 import { JourneyEditModal } from '../trek/JourneyEditModal';
 import { RouteEditor } from '../trek/RouteEditor';
+import { FunFactCard } from '../journey/FunFactCard';
+import { DayDiscoveries } from '../journey/DayDiscoveries';
 
 interface BottomSheetContentProps {
     view: ViewMode;
@@ -570,6 +572,44 @@ function DayContent({ camp, currentDayDate, dayPhotos, allPhotos, getMediaUrl, o
                     ))}
                 </ul>
             )}
+
+            {/* Fun Facts */}
+            {camp.funFacts && camp.funFacts.length > 0 && (
+                <div style={{ marginBottom: 16 }}>
+                    <div
+                        style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 6,
+                            marginBottom: 10,
+                        }}
+                    >
+                        <span style={{ fontSize: 14 }}>💡</span>
+                        <span
+                            style={{
+                                fontSize: 11,
+                                fontWeight: 600,
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.08em',
+                                color: colors.text.tertiary,
+                            }}
+                        >
+                            Did you know?
+                        </span>
+                    </div>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                        {camp.funFacts.map((fact) => (
+                            <FunFactCard key={fact.id} fact={fact} compact />
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {/* Points of Interest & Historical Sites */}
+            <DayDiscoveries
+                pointsOfInterest={camp.pointsOfInterest}
+                historicalSites={camp.historicalSites}
+            />
 
             {/* View gallery button */}
             {dayPhotos.length > 0 && (

--- a/src/components/trek/RouteEditor.tsx
+++ b/src/components/trek/RouteEditor.tsx
@@ -19,7 +19,7 @@ import { useState, useRef, useEffect, useCallback, memo, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
-import { motion, AnimatePresence, Reorder, useDragControls } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import type { TrekData, Camp, Route } from '../../types/trek';
 import { Button } from '../ui/button';
 import { cn } from '@/lib/utils';
@@ -132,7 +132,6 @@ const MobileCampItem = memo(function MobileCampItem({
     onSelect,
     onRequestDelete,
 }: MobileCampItemProps) {
-    const dragControls = useDragControls();
     const [swipeX, setSwipeX] = useState(0);
     const [isDragging, setIsDragging] = useState(false);
     const startX = useRef(0);
@@ -200,10 +199,11 @@ const MobileCampItem = memo(function MobileCampItem({
     const deleteOpacity = Math.min(1, Math.abs(swipeX) / (DELETE_BUTTON_WIDTH * 0.6));
 
     return (
-        <Reorder.Item
-            value={camp}
-            dragListener={false}
-            dragControls={dragControls}
+        <motion.div
+            layout
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
             style={{ marginBottom: 8 }}
         >
             <div
@@ -290,25 +290,6 @@ const MobileCampItem = memo(function MobileCampItem({
                             : `0 4px 16px rgba(0, 0, 0, 0.2), inset 0 1px 0 ${colors.glass.highlight}`,
                     }}
                 >
-                    {/* Drag handle - subtle glass lines */}
-                    <div
-                        onPointerDown={(e) => dragControls.start(e)}
-                        style={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: 3,
-                            padding: '6px 6px',
-                            cursor: 'grab',
-                            touchAction: 'none',
-                            borderRadius: radius.sm,
-                            background: 'rgba(255, 255, 255, 0.03)',
-                        }}
-                    >
-                        <div style={{ width: 14, height: 2, background: 'rgba(255, 255, 255, 0.25)', borderRadius: 1 }} />
-                        <div style={{ width: 14, height: 2, background: 'rgba(255, 255, 255, 0.25)', borderRadius: 1 }} />
-                        <div style={{ width: 14, height: 2, background: 'rgba(255, 255, 255, 0.25)', borderRadius: 1 }} />
-                    </div>
-
                     {/* Camp number badge - glass style */}
                     <div
                         style={{
@@ -384,7 +365,7 @@ const MobileCampItem = memo(function MobileCampItem({
                     </motion.div>
                 </motion.div>
             </div>
-        </Reorder.Item>
+        </motion.div>
     );
 });
 
@@ -474,7 +455,6 @@ const DesktopCampItem = memo(function DesktopCampItem({
     onSelect,
     onRequestDelete,
 }: DesktopCampItemProps) {
-    const dragControls = useDragControls();
     const [isHovered, setIsHovered] = useState(false);
 
     const handleDelete = useCallback((e: React.MouseEvent) => {
@@ -483,10 +463,11 @@ const DesktopCampItem = memo(function DesktopCampItem({
     }, [onRequestDelete]);
 
     return (
-        <Reorder.Item
-            value={camp}
-            dragListener={false}
-            dragControls={dragControls}
+        <motion.div
+            layout
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
             style={{ marginBottom: 6 }}
         >
             <div
@@ -519,24 +500,6 @@ const DesktopCampItem = memo(function DesktopCampItem({
                     transition: `all ${transitions.fast}`,
                 }}
             >
-                {/* Drag handle */}
-                <div
-                    onPointerDown={(e) => dragControls.start(e)}
-                    style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: 2,
-                        padding: '4px 2px',
-                        cursor: 'grab',
-                        opacity: isHovered || isSelected ? 0.6 : 0.3,
-                        transition: `opacity ${transitions.fast}`,
-                    }}
-                >
-                    <div style={{ width: 12, height: 2, background: 'rgba(255, 255, 255, 0.4)', borderRadius: 1 }} />
-                    <div style={{ width: 12, height: 2, background: 'rgba(255, 255, 255, 0.4)', borderRadius: 1 }} />
-                    <div style={{ width: 12, height: 2, background: 'rgba(255, 255, 255, 0.4)', borderRadius: 1 }} />
-                </div>
-
                 {/* Camp number badge */}
                 <div
                     style={{
@@ -630,7 +593,7 @@ const DesktopCampItem = memo(function DesktopCampItem({
                     )}
                 </AnimatePresence>
             </div>
-        </Reorder.Item>
+        </motion.div>
     );
 });
 
@@ -1052,7 +1015,7 @@ export const RouteEditor = memo(function RouteEditor({
         });
     }, []);
 
-    // Memoized sorted camps for Reorder.Group (stable reference that updates when camps change)
+    // Memoized sorted camps (stable reference that updates when camps change)
     const sortedCamps = useMemo(() => sortCamps(camps), [camps, sortCamps]);
 
     // Update markers when camps change
@@ -2858,24 +2821,10 @@ export const RouteEditor = memo(function RouteEditor({
                         {/* Hint */}
                         {camps.length > 0 && (
                             <div className="text-center text-white/30 text-[10px] mb-2 px-2">
-                                Drag to reorder • Swipe left to delete
+                                Swipe left to delete
                             </div>
                         )}
-                        <Reorder.Group
-                            axis="y"
-                            values={sortedCamps}
-                            onReorder={(reorderedCamps) => {
-                                // Update routeDistanceKm to preserve new order
-                                const updatedCamps = reorderedCamps.map((camp, idx) => ({
-                                    ...camp,
-                                    routeDistanceKm: idx, // Use index as distance to maintain order
-                                    isDirty: true,
-                                }));
-                                setCamps(updatedCamps);
-                                setHasChanges(true);
-                            }}
-                            style={{ listStyle: 'none', padding: 0, margin: 0 }}
-                        >
+                        <AnimatePresence mode="popLayout">
                             {sortedCamps.map((camp, index) => (
                                 <MobileCampItem
                                     key={camp.id}
@@ -2891,7 +2840,7 @@ export const RouteEditor = memo(function RouteEditor({
                                     }}
                                 />
                             ))}
-                        </Reorder.Group>
+                        </AnimatePresence>
                     </div>
 
                     {/* Has changes indicator */}
@@ -3322,23 +3271,10 @@ export const RouteEditor = memo(function RouteEditor({
                                         marginBottom: 8,
                                         padding: '0 8px',
                                     }}>
-                                        Drag to reorder • Hover to delete
+                                        Hover to delete
                                     </div>
                                 )}
-                                <Reorder.Group
-                                    axis="y"
-                                    values={sortedCamps}
-                                    onReorder={(reorderedCamps) => {
-                                        const updatedCamps = reorderedCamps.map((camp, idx) => ({
-                                            ...camp,
-                                            routeDistanceKm: idx,
-                                            isDirty: true,
-                                        }));
-                                        setCamps(updatedCamps);
-                                        setHasChanges(true);
-                                    }}
-                                    style={{ listStyle: 'none', padding: 0, margin: 0 }}
-                                >
+                                <AnimatePresence mode="popLayout">
                                     {sortedCamps.map((camp, index) => (
                                         <DesktopCampItem
                                             key={camp.id}
@@ -3354,7 +3290,7 @@ export const RouteEditor = memo(function RouteEditor({
                                             }}
                                         />
                                     ))}
-                                </Reorder.Group>
+                                </AnimatePresence>
                             </div>
 
                             {/* Has changes indicator */}

--- a/src/lib/journeys/transforms.ts
+++ b/src/lib/journeys/transforms.ts
@@ -159,11 +159,6 @@ export function toTrekData(journey: DbJourney, waypoints: DbWaypoint[]): TrekDat
 
         const dayNumber = w.day_number || i + 1;
 
-        // Debug: Log fun facts data
-        if (w.fun_facts && w.fun_facts.length > 0) {
-            console.log(`[transforms] Camp "${w.name}" has ${w.fun_facts.length} fun facts`);
-        }
-
         return {
             id: w.id,
             name: w.name,

--- a/src/lib/journeys/transforms.ts
+++ b/src/lib/journeys/transforms.ts
@@ -3,8 +3,8 @@
  * Converts database records to app types
  */
 
-import type { TrekConfig, TrekData, Camp } from '../../types/trek';
-import type { DbJourney, DbWaypoint } from './types';
+import type { TrekConfig, TrekData, Camp, FunFact, PointOfInterest, HistoricalSite, FunFactCategory, POICategory } from '../../types/trek';
+import type { DbJourney, DbWaypoint, DbFunFact, DbPointOfInterest, DbHistoricalSite } from './types';
 
 /**
  * Transform database journey to TrekConfig (for globe markers)
@@ -72,6 +72,59 @@ export function calculateElevationGainBetweenIndices(
 }
 
 /**
+ * Transform database fun fact to app type
+ */
+function toFunFact(dbFact: DbFunFact): FunFact {
+    return {
+        id: dbFact.id,
+        content: dbFact.content,
+        category: dbFact.category as FunFactCategory,
+        source: dbFact.source,
+        learnMoreUrl: dbFact.learn_more_url,
+        icon: dbFact.icon,
+    };
+}
+
+/**
+ * Transform database point of interest to app type
+ */
+function toPointOfInterest(dbPoi: DbPointOfInterest): PointOfInterest {
+    return {
+        id: dbPoi.id,
+        name: dbPoi.name,
+        category: dbPoi.category as POICategory,
+        coordinates: dbPoi.coordinates,
+        elevation: dbPoi.elevation,
+        description: dbPoi.description,
+        routeDistanceKm: dbPoi.route_distance_km,
+        tips: dbPoi.tips,
+        timeFromPrevious: dbPoi.time_from_previous,
+        icon: dbPoi.icon,
+    };
+}
+
+/**
+ * Transform database historical site to app type
+ */
+function toHistoricalSite(dbSite: DbHistoricalSite, dayNumber?: number): HistoricalSite {
+    return {
+        id: dbSite.id,
+        name: dbSite.name,
+        coordinates: dbSite.coordinates,
+        elevation: dbSite.elevation,
+        routeDistanceKm: dbSite.route_distance_km,
+        summary: dbSite.summary,
+        description: dbSite.description,
+        period: dbSite.period,
+        significance: dbSite.significance,
+        imageUrls: dbSite.image_urls,
+        links: dbSite.links,
+        tags: dbSite.tags,
+        dayNumber,
+    };
+}
+
+/**
  * Transform database journey + waypoints to TrekData
  */
 export function toTrekData(journey: DbJourney, waypoints: DbWaypoint[]): TrekData {
@@ -104,10 +157,12 @@ export function toTrekData(journey: DbJourney, waypoints: DbWaypoint[]): TrekDat
             );
         }
 
+        const dayNumber = w.day_number || i + 1;
+
         return {
             id: w.id,
             name: w.name,
-            dayNumber: w.day_number || i + 1,
+            dayNumber,
             elevation: w.elevation || 0,
             coordinates: w.coordinates,
             elevationGainFromPrevious,
@@ -122,6 +177,9 @@ export function toTrekData(journey: DbJourney, waypoints: DbWaypoint[]): TrekDat
                 windSpeedMax: w.weather.wind_speed_max,
                 weatherCode: w.weather.weather_code,
             } : null,
+            funFacts: w.fun_facts?.map(toFunFact) || [],
+            pointsOfInterest: w.points_of_interest?.map(toPointOfInterest) || [],
+            historicalSites: w.historical_sites?.map(s => toHistoricalSite(s, dayNumber)) || [],
         };
     });
 

--- a/src/lib/journeys/transforms.ts
+++ b/src/lib/journeys/transforms.ts
@@ -159,6 +159,11 @@ export function toTrekData(journey: DbJourney, waypoints: DbWaypoint[]): TrekDat
 
         const dayNumber = w.day_number || i + 1;
 
+        // Debug: Log fun facts data
+        if (w.fun_facts && w.fun_facts.length > 0) {
+            console.log(`[transforms] Camp "${w.name}" has ${w.fun_facts.length} fun facts`);
+        }
+
         return {
             id: w.id,
             name: w.name,

--- a/src/lib/journeys/types.ts
+++ b/src/lib/journeys/types.ts
@@ -42,6 +42,46 @@ export interface WeatherData {
     fetched_at: string;
 }
 
+/** Fun fact stored in database (JSONB) */
+export interface DbFunFact {
+    id: string;
+    content: string;
+    category: string;
+    source?: string;
+    learn_more_url?: string;
+    icon?: string;
+}
+
+/** Point of interest stored in database (JSONB) */
+export interface DbPointOfInterest {
+    id: string;
+    name: string;
+    category: string;
+    coordinates: [number, number];
+    elevation?: number;
+    description?: string;
+    route_distance_km?: number;
+    tips?: string[];
+    time_from_previous?: string;
+    icon?: string;
+}
+
+/** Historical site stored in database (JSONB) */
+export interface DbHistoricalSite {
+    id: string;
+    name: string;
+    coordinates: [number, number];
+    elevation?: number;
+    route_distance_km?: number;
+    summary: string;
+    description?: string;
+    period?: string;
+    significance?: 'major' | 'minor' | 'notable';
+    image_urls?: string[];
+    links?: { label: string; url: string }[];
+    tags?: string[];
+}
+
 export interface DbWaypoint {
     id: string;
     journey_id: string;
@@ -59,4 +99,10 @@ export interface DbWaypoint {
     route_point_index: number | null;
     /** Historical weather data for the day */
     weather: WeatherData | null;
+    /** Fun facts for this day (JSONB) */
+    fun_facts: DbFunFact[] | null;
+    /** Points of interest for this day (JSONB) */
+    points_of_interest: DbPointOfInterest[] | null;
+    /** Historical sites for this day (JSONB) */
+    historical_sites: DbHistoricalSite[] | null;
 }

--- a/src/types/trek.ts
+++ b/src/types/trek.ts
@@ -40,6 +40,12 @@ export interface Camp {
     routePointIndex?: number | null;
     /** Historical weather data for the day */
     weather?: WeatherData | null;
+    /** Fun facts for this day */
+    funFacts?: FunFact[];
+    /** Points of interest encountered on this day */
+    pointsOfInterest?: PointOfInterest[];
+    /** Historical sites encountered on this day */
+    historicalSites?: HistoricalSite[];
 }
 
 export interface Route {
@@ -279,6 +285,41 @@ export interface HistoricalSite {
     links?: { label: string; url: string }[];
     /** Tags for categorization */
     tags?: string[];
+    /** Associated day number (for day-specific display) */
+    dayNumber?: number;
+}
+
+/**
+ * Fun fact category for categorizing trivia
+ */
+export type FunFactCategory =
+    | 'geology'       // Mountain formation, rock types, terrain
+    | 'wildlife'      // Animals, birds, insects
+    | 'flora'         // Plants, trees, vegetation zones
+    | 'history'       // Historical events, explorers
+    | 'culture'       // Local traditions, indigenous peoples
+    | 'climate'       // Weather patterns, seasons
+    | 'adventure'     // Climbing records, expeditions
+    | 'science'       // Scientific research, discoveries
+    | 'geography'     // Location facts, borders, regions
+    | 'survival';     // Altitude tips, trekking advice
+
+/**
+ * Fun fact for journey days
+ * Interesting trivia and educational content
+ */
+export interface FunFact {
+    id: string;
+    /** The fact content */
+    content: string;
+    /** Category of the fact */
+    category: FunFactCategory;
+    /** Optional source/reference */
+    source?: string;
+    /** Optional link for more info */
+    learnMoreUrl?: string;
+    /** Icon to display (optional, uses category default) */
+    icon?: string;
 }
 
 export type ViewMode = 'globe' | 'trek';

--- a/supabase/migrations/20251218000000_add_fun_facts_and_discoveries.sql
+++ b/supabase/migrations/20251218000000_add_fun_facts_and_discoveries.sql
@@ -1,0 +1,19 @@
+-- Add fun facts, points of interest, and historical sites to waypoints
+-- These are stored as JSONB arrays for flexible content
+
+-- Fun facts for each day (educational trivia)
+ALTER TABLE waypoints
+ADD COLUMN IF NOT EXISTS fun_facts JSONB DEFAULT '[]'::jsonb;
+
+-- Points of interest encountered on each day
+ALTER TABLE waypoints
+ADD COLUMN IF NOT EXISTS points_of_interest JSONB DEFAULT '[]'::jsonb;
+
+-- Historical sites encountered on each day
+ALTER TABLE waypoints
+ADD COLUMN IF NOT EXISTS historical_sites JSONB DEFAULT '[]'::jsonb;
+
+-- Add comments for documentation
+COMMENT ON COLUMN waypoints.fun_facts IS 'Array of fun facts [{id, content, category, source?, learn_more_url?, icon?}]';
+COMMENT ON COLUMN waypoints.points_of_interest IS 'Array of POIs [{id, name, category, coordinates, elevation?, description?, route_distance_km?, tips?, time_from_previous?, icon?}]';
+COMMENT ON COLUMN waypoints.historical_sites IS 'Array of historical sites [{id, name, coordinates, elevation?, route_distance_km?, summary, description?, period?, significance?, image_urls?, links?, tags?}]';


### PR DESCRIPTION
- Add FunFact and FunFactCategory types for educational trivia
- Add dayNumber to HistoricalSite for day-level association
- Update Camp interface with funFacts, pointsOfInterest, and historicalSites
- Update database types (DbFunFact, DbPointOfInterest, DbHistoricalSite)
- Create FunFactCard component with category icons and colors
- Create DayDiscoveries component for POIs and historical sites
- Update DayChapter to display fun facts and discoveries
- Add transforms for new data types from database to app models
- Add database migration for new JSONB columns
- Add populateFunFacts.ts script with Kilimanjaro sample data

The feature enables educational content per day including:
- Fun facts with categories (geology, wildlife, history, etc.)
- Points of interest with tips and descriptions
- Historical sites with significance levels and external links