### PR TITLE
fix(ci): Repair apple-ci workflow YAML

### DIFF
--- a/.github/workflows/apple-ci.yml
+++ b/.github/workflows/apple-ci.yml
@@ -36,11 +36,9 @@ jobs:
       - name: Pick an available iPhone simulator
         id: sim
         run: |
-          UDID=$(xcrun simctl list devices available -j | python3 -c "import json,sys
-data = json.load(sys.stdin)['devices']
-ids = [d['udid'] for rt, devs in data.items() if 'iOS' in rt
-       for d in devs if d.get('isAvailable') and d['name'].startswith('iPhone')]
-print(ids[-1] if ids else '')")
+          # Keep the Python on ONE line: an unindented continuation line ends the
+          # YAML block scalar, which makes GitHub reject the whole workflow file.
+          UDID=$(xcrun simctl list devices available -j | python3 -c "import json,sys; data=json.load(sys.stdin)['devices']; ids=[d['udid'] for rt, devs in data.items() if 'iOS' in rt for d in devs if d.get('isAvailable') and d['name'].startswith('iPhone')]; print(ids[-1] if ids else '')")
           if [ -z "$UDID" ]; then echo "No iOS simulator available" >&2; exit 1; fi
           echo "udid=$UDID" >> "$GITHUB_OUTPUT"
           echo "Selected simulator: $UDID"

--- a/apple/Akashic/Views/Photos/PhotoLightboxView.swift
+++ b/apple/Akashic/Views/Photos/PhotoLightboxView.swift
@@ -45,10 +45,19 @@ struct PhotoLightboxView: View {
 
     private var allowsEditing: Bool { journey != nil }
 
+    /// Backdrop fades out as the swipe-to-dismiss drag grows. Types are spelled out:
+    /// mixing integer and floating-point literals here is ambiguous to older type
+    /// checkers (Xcode 16 fails to compile it).
+    private var backdropOpacity: Double {
+        let dragSpan: CGFloat = 400
+        let maxFade: CGFloat = 0.6
+        return 1 - Double(min(abs(dragOffset) / dragSpan, maxFade))
+    }
+
     var body: some View {
         ZStack {
             Color.black.ignoresSafeArea()
-                .opacity(1 - min(abs(dragOffset) / 400, 0.6))
+                .opacity(backdropOpacity)
 
             pager
                 .offset(y: dragOffset)


### PR DESCRIPTION
## Problem

`apple-ci.yml` has never run. Every attempt failed at startup with zero jobs, and the Actions list showed the file path instead of the workflow name — the tell-tale sign GitHub cannot parse the file.

Root cause: the simulator-picking step embedded multi-line Python whose continuation lines began at column 0. In YAML a `run: |` block scalar ends at the first line indented less than the block, so the rest of the file was parsed as garbage.

## Fix

Collapsed the Python to a single line. Verified locally that the file now parses (`YAML OK; jobs: ["build-test"]`) and that the one-liner selects a real simulator UDID.

## Test plan
- [x] YAML parses
- [x] Simulator selection one-liner returns a valid UDID locally
- [ ] The workflow actually runs green on this PR (this PR touches `.github/workflows/apple-ci.yml`, which is in its own trigger paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)