### PR TITLE
Polish pass: empty states, truncated stats, and the screens nobody could look at

### DIFF
--- a/apple/Akashic/App/Config.swift
+++ b/apple/Akashic/App/Config.swift
@@ -65,7 +65,16 @@ enum Config {
     static let coreDataModelName = "Akashic"
     static let persistenceModeOverrideKey = "akashic.persistenceMode.override"
 
-    // MARK: - Data import (T2.4)
+    /// `AKASHIC_EMPTY=1` — start with no journeys at all, in any persistence mode.
+    ///
+    /// This is the state every new customer is in on first launch, and without this flag it could
+    /// only be reached with a signed CloudKit build signed into an empty iCloud account. Used for
+    /// inspecting the empty states and for the App Store screenshot of a fresh install.
+    static var startEmpty: Bool {
+        ProcessInfo.processInfo.environment["AKASHIC_EMPTY"] == "1"
+    }
+
+    // MARK: - Data import (T2.5)
 
     static let importBundlePathKey = "akashic.import.bundlePath"
     static let importMediaRootKey = "akashic.import.mediaRoot"

--- a/apple/Akashic/Persistence/PersistenceController.swift
+++ b/apple/Akashic/Persistence/PersistenceController.swift
@@ -117,7 +117,11 @@ final class PersistenceController {
             MainActor.assumeIsolated { startSync() }
         }
 
-        guard seed else { return }
+        // `AKASHIC_EMPTY=1` keeps the store empty in every mode. Without it, the state a brand-new
+        // customer actually sees — no journeys at all — could only be reached with a signed
+        // CloudKit build and an empty iCloud account, which made the app's most important screen
+        // the hardest one for its author to look at (and impossible to screenshot for the store).
+        guard seed, !Config.startEmpty else { return }
         switch mode {
         case .fixtures:
             seedFixtures(bundle: fixtureBundle)

--- a/apple/Akashic/Views/Edit/RouteCorrectionSection.swift
+++ b/apple/Akashic/Views/Edit/RouteCorrectionSection.swift
@@ -27,11 +27,18 @@ struct RouteCorrectionSection: View {
     @State private var showingDrawing = false
     @State private var drawnRoute: RouteDrawing.DrawnRoute?
 
+    /// Whether this journey already has a route — decides "Import" vs "Replace" wording.
+    private var hasRoute: Bool { !journey.route.coordinates.isEmpty }
+
     var body: some View {
         GlassField(label: "Route", systemImage: "point.topleft.down.to.point.bottomright.curvepath") {
             VStack(alignment: .leading, spacing: 10) {
-                row(icon: "arrow.down.doc", title: "Replace route from GPX",
-                    subtitle: "Import a new track — preview before it replaces this route") {
+                // A journey with no route yet is not "replacing" anything — the verb follows reality.
+                row(icon: "arrow.down.doc",
+                    title: hasRoute ? "Replace route from GPX" : "Import route from GPX",
+                    subtitle: hasRoute
+                        ? "Import a new track — preview before it replaces this route"
+                        : "Import a track from Strava, Garmin, AllTrails or komoot") {
                     message = nil
                     showingImporter = true
                 }
@@ -39,14 +46,17 @@ struct RouteCorrectionSection: View {
                     subtitle: "Build a route from this journey's geotagged photos") {
                     draftFromPhotos()
                 }
-                row(icon: "scribble", title: "Draw route on map",
+                row(icon: "scribble", title: hasRoute ? "Redraw route on map" : "Draw route on map",
                     subtitle: "Trace the route by hand — no track or geotags needed") {
                     message = nil
                     showingDrawing = true
                 }
-                row(icon: "function", title: "Recompute stats from route",
-                    subtitle: "Refresh distance, ascent and summit from the current route") {
-                    recomputeStats()
+                // Nothing to recompute from until a route exists.
+                if hasRoute {
+                    row(icon: "function", title: "Recompute stats from route",
+                        subtitle: "Refresh distance, ascent and summit from the current route") {
+                        recomputeStats()
+                    }
                 }
                 if let message {
                     Text(message).font(.caption2).foregroundStyle(Theme.textTertiary)

--- a/apple/Akashic/Views/JourneyDetailView.swift
+++ b/apple/Akashic/Views/JourneyDetailView.swift
@@ -230,12 +230,25 @@ struct JourneyDetailView: View {
         }
     }
 
+    /// Absent is shown as "—", never as 0. A journey created a minute ago has no route, and a
+    /// hand-drawn one has no elevation; "0 km" and "0 m Summit" read as measurements that came back
+    /// zero rather than numbers nobody has supplied yet.
     private var statsSummary: some View {
-        StatChipRow(items: [
-            .init(icon: "figure.walk", value: Formatters.distanceKm(live.stats.totalDistance), caption: "Distance"),
-            .init(icon: "arrow.up.forward", value: Formatters.meters(live.stats.totalElevationGain), caption: "Ascent"),
-            .init(icon: "mountain.2", value: Formatters.meters(live.stats.highestPoint?.elevation ?? 0), caption: "Summit"),
-            .init(icon: "calendar", value: "\(live.stats.duration)", caption: "Days"),
+        let route = live.route
+        let hasRoute = !route.coordinates.isEmpty
+        return StatChipRow(items: [
+            .init(icon: "figure.walk",
+                  value: hasRoute ? Formatters.distanceKm(live.stats.totalDistance) : "—",
+                  caption: "Distance"),
+            .init(icon: "arrow.up.forward",
+                  value: route.hasElevation ? Formatters.meters(live.stats.totalElevationGain) : "—",
+                  caption: "Ascent"),
+            .init(icon: "mountain.2",
+                  value: live.stats.highestPoint.map { Formatters.meters($0.elevation) } ?? "—",
+                  caption: "Summit"),
+            .init(icon: "calendar",
+                  value: live.stats.duration > 0 ? "\(live.stats.duration)" : "—",
+                  caption: "Days"),
         ])
     }
 

--- a/apple/Akashic/Views/JourneyDetailView.swift
+++ b/apple/Akashic/Views/JourneyDetailView.swift
@@ -38,16 +38,22 @@ struct JourneyDetailView: View {
             VStack(alignment: .leading, spacing: 20) {
                 header
 
-                RouteMapView(journey: journey, interactive: false)
-                    .frame(height: 220)
-                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 18, style: .continuous)
-                            .strokeBorder(Theme.hairline, lineWidth: 1)
-                    )
+                if live.isEmptyShell {
+                    // Nothing to draw a map of and nothing to total up. Offer the ways in instead
+                    // of rendering the content screens over an empty journey.
+                    nextSteps
+                } else {
+                    RouteMapView(journey: journey, interactive: false)
+                        .frame(height: 220)
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .strokeBorder(Theme.hairline, lineWidth: 1)
+                        )
 
-                statsSummary
-                photosLink
+                    statsSummary
+                    if photoCount > 0 { photosLink }
+                }
 
                 if !live.description.isEmpty {
                     Text(live.description)
@@ -55,7 +61,7 @@ struct JourneyDetailView: View {
                         .foregroundStyle(Theme.textSecondary)
                 }
 
-                daySection
+                if !live.isEmptyShell { daySection }
             }
             .padding(16)
         }
@@ -183,6 +189,35 @@ struct JourneyDetailView: View {
                 set: { if !$0 { selectedDayIndex = nil } })
     }
 
+    private var photoCount: Int { store.photos(forJourneyID: journey.id).count }
+
+    /// The ways into an empty journey. Owner-only: a shared-in journey is not ours to fill, so a
+    /// participant gets the explanation without buttons that would fail.
+    private var nextSteps: some View {
+        JourneyNextStepsCard(
+            title: "This journey is empty",
+            message: isOwner
+                ? "Add a route, days or photos and it comes to life on the globe."
+                : "Nothing has been added to this journey yet. Its owner can add a route, days and photos.",
+            steps: isOwner ? [
+                .init(icon: "point.topleft.down.to.point.bottomright.curvepath",
+                      title: "Add a route",
+                      subtitle: "Import a GPX from Strava, Garmin or komoot — or draw it by hand") {
+                          showJourneyEdit = true
+                      },
+                .init(icon: "calendar.badge.plus",
+                      title: "Add days",
+                      subtitle: "Build the day-by-day story, or seed days from your photo dates") {
+                          showManageDays = true
+                      },
+                .init(icon: "photo.badge.plus",
+                      title: "Add photos",
+                      subtitle: "Photos carry their own dates and locations") {
+                          showImport = true
+                      },
+            ] : [])
+    }
+
     private var photosLink: some View {
         NavigationLink {
             PhotosGridView(journeyID: journey.id)
@@ -252,11 +287,42 @@ struct JourneyDetailView: View {
         ])
     }
 
+    @ViewBuilder
     private var daySection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Days")
                 .font(.title3.weight(.semibold))
                 .foregroundStyle(Theme.textPrimary)
+            // A route without days (a bare GPX import, or a drawn route) used to leave this heading
+            // standing over nothing.
+            if live.camps.isEmpty {
+                Button { showManageDays = true } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "calendar.badge.plus")
+                            .font(.title3).foregroundStyle(Theme.accent).frame(width: 26)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(isOwner ? "No days yet" : "No days yet")
+                                .font(.subheadline.weight(.semibold)).foregroundStyle(Theme.textPrimary)
+                            Text(isOwner
+                                 ? "Add them one by one, or let your photo dates propose them"
+                                 : "The owner hasn't added days to this journey")
+                                .font(.caption2).foregroundStyle(Theme.textTertiary)
+                        }
+                        Spacer(minLength: 8)
+                        if isOwner {
+                            Image(systemName: "chevron.right")
+                                .font(.footnote).foregroundStyle(Theme.textTertiary)
+                        }
+                    }
+                    .padding(12)
+                    .frame(maxWidth: .infinity)
+                    .background(Theme.surface, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(Theme.hairline, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+                .disabled(!isOwner)
+            }
             ForEach(Array(live.camps.enumerated()), id: \.element.id) { index, camp in
                 Button {
                     selectedDayIndex = index

--- a/apple/Akashic/Views/JourneyDetailView.swift
+++ b/apple/Akashic/Views/JourneyDetailView.swift
@@ -231,12 +231,12 @@ struct JourneyDetailView: View {
     }
 
     private var statsSummary: some View {
-        HStack(spacing: 10) {
-            StatChip(icon: "figure.walk", value: Formatters.distanceKm(live.stats.totalDistance), caption: "Distance")
-            StatChip(icon: "arrow.up.forward", value: Formatters.meters(live.stats.totalElevationGain), caption: "Ascent")
-            StatChip(icon: "mountain.2", value: Formatters.meters(live.stats.highestPoint?.elevation ?? 0), caption: "Summit")
-            StatChip(icon: "calendar", value: "\(live.stats.duration)", caption: "Days")
-        }
+        StatChipRow(items: [
+            .init(icon: "figure.walk", value: Formatters.distanceKm(live.stats.totalDistance), caption: "Distance"),
+            .init(icon: "arrow.up.forward", value: Formatters.meters(live.stats.totalElevationGain), caption: "Ascent"),
+            .init(icon: "mountain.2", value: Formatters.meters(live.stats.highestPoint?.elevation ?? 0), caption: "Summit"),
+            .init(icon: "calendar", value: "\(live.stats.duration)", caption: "Days"),
+        ])
     }
 
     private var daySection: some View {

--- a/apple/Akashic/Views/JourneyNextSteps.swift
+++ b/apple/Akashic/Views/JourneyNextSteps.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+extension Journey {
+    /// A journey that exists but holds nothing yet: no route, no days. Legitimate — §4.1 keeps
+    /// "no route yet" a valid state because photos-only trips exist — and it is the state EVERY new
+    /// customer is in for their first minutes, which is why it needs its own answer rather than the
+    /// content screens rendered over nothing.
+    var isEmptyShell: Bool { route.coordinates.isEmpty && camps.isEmpty }
+}
+
+/// What to do next with a journey that has nothing in it yet.
+///
+/// Before this existed the app answered the question with silence: the globe flew into an empty
+/// ocean, the detail screen showed a world-sized map thumbnail, four stat chips reading zero, and a
+/// bare "Days" heading over nothing. Nothing was broken and there was nothing to do either — the
+/// worst possible first impression for the one screen the beta gate measures ("≥7 of 10 families
+/// complete a journey unaided").
+///
+/// The steps are supplied by the caller so each host offers only what it can actually do.
+struct JourneyNextStepsCard: View {
+    struct Step: Identifiable {
+        var icon: String
+        var title: String
+        var subtitle: String
+        var action: () -> Void
+        var id: String { title }
+    }
+
+    var title: String
+    var message: String
+    var steps: [Step] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if !steps.isEmpty {
+                VStack(spacing: 10) {
+                    ForEach(steps) { step in
+                        Button(action: step.action) {
+                            HStack(spacing: 12) {
+                                Image(systemName: step.icon)
+                                    .font(.title3)
+                                    .foregroundStyle(Theme.accent)
+                                    .frame(width: 26)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(step.title)
+                                        .font(.subheadline.weight(.semibold))
+                                        .foregroundStyle(Theme.textPrimary)
+                                    Text(step.subtitle)
+                                        .font(.caption2)
+                                        .foregroundStyle(Theme.textTertiary)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                                Spacer(minLength: 8)
+                                Image(systemName: "chevron.right")
+                                    .font(.footnote)
+                                    .foregroundStyle(Theme.textTertiary)
+                            }
+                            .padding(12)
+                            .frame(maxWidth: .infinity)
+                            .background(Theme.surfaceRaised, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .strokeBorder(Theme.hairline, lineWidth: 1))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.surface, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 20, style: .continuous)
+            .strokeBorder(Theme.hairline, lineWidth: 1))
+    }
+}
+
+/// The globe's version of the same message: one line and one way out, because the globe has no
+/// editing surface of its own. Sized to sit where `DayNavigationView` would.
+struct JourneyNothingToShowPill: View {
+    let journeyName: String
+    var onOpen: () -> Void
+
+    var body: some View {
+        VStack(spacing: 10) {
+            VStack(spacing: 2) {
+                Text("Nothing to show yet")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(Theme.textPrimary)
+                Text("\(journeyName) has no route, days or photos")
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Button(action: onOpen) {
+                Label("Open journey", systemImage: "arrow.up.forward.app")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Theme.background)
+                    .padding(.vertical, 10)
+                    .padding(.horizontal, 18)
+                    .background(Theme.accent, in: Capsule())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .strokeBorder(Theme.hairline, lineWidth: 1))
+        .padding(.horizontal, 12)
+    }
+}

--- a/apple/Akashic/Views/Map/DayNavigationView.swift
+++ b/apple/Akashic/Views/Map/DayNavigationView.swift
@@ -53,7 +53,8 @@ struct DayNavigationView: View {
                         .foregroundStyle(Theme.textSecondary)
                         .lineLimit(1)
                 } else {
-                    Text("\(camps.count) days")
+                    // "0 days" is what a journey with a route but no days used to announce.
+                    Text(camps.isEmpty ? "No days yet" : "\(camps.count) days")
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundStyle(MapPalette.cyan)
                     Text(journey.shortName)

--- a/apple/Akashic/Views/Map/GlobeExperienceView.swift
+++ b/apple/Akashic/Views/Map/GlobeExperienceView.swift
@@ -34,6 +34,8 @@ struct GlobeExperienceView: View {
     @State private var dayLightbox: LightboxData?
     @State private var sheetDetent: PresentationDetent = .medium
     @State private var showingPhotoGrid = false
+    /// The globe's route into a journey's own screen — the only place an empty journey can be filled.
+    @State private var showingJourneyDetail = false
     @State private var showingNewJourney = false
     @State private var showingPaywall = false
 
@@ -94,6 +96,14 @@ struct GlobeExperienceView: View {
             if let journey = controller.selectedJourney {
                 NavigationStack { PhotosGridView(journeyID: journey.id) }
                     .environmentObject(store)
+                    .preferredColorScheme(.dark)
+            }
+        }
+        .sheet(isPresented: $showingJourneyDetail) {
+            if let journey = controller.selectedJourney {
+                NavigationStack { JourneyDetailView(journey: journey) }
+                    .environmentObject(store)
+                    .environmentObject(entitlements)
                     .preferredColorScheme(.dark)
             }
         }
@@ -347,9 +357,17 @@ struct GlobeExperienceView: View {
                 }
             } else if let journey = controller.selectedJourney,
                       controller.selectedDayIndex == nil {
-                // In overview: the day navigator picks a starting day. Once a day is
-                // selected, the DayDetailSheet takes over (and covers this area).
-                DayNavigationView(journey: journey, controller: controller)
+                if journey.isEmptyShell {
+                    // Flying into a journey with no route and no days lands on empty ocean — the
+                    // camera has nothing to frame. Say so, and offer the one screen that can fix it.
+                    JourneyNothingToShowPill(journeyName: journey.shortName) {
+                        showingJourneyDetail = true
+                    }
+                } else {
+                    // In overview: the day navigator picks a starting day. Once a day is
+                    // selected, the DayDetailSheet takes over (and covers this area).
+                    DayNavigationView(journey: journey, controller: controller)
+                }
             }
         }
         .padding(.top, 8)

--- a/apple/Akashic/Views/RootView.swift
+++ b/apple/Akashic/Views/RootView.swift
@@ -14,7 +14,15 @@ struct RootView: View {
     @ObservedObject private var networkPolicy = NetworkPolicy.shared
 
     init() {
-        // Dark, translucent tab + nav bars consistent with the night-sky palette.
+        // The app runs `.preferredColorScheme(.dark)`, so the system bars are already dark and
+        // already the right material. Below iOS 26 they are flat, and an opaque fill matching the
+        // night-sky palette reads better than the default grey; from iOS 26 the bars are Liquid
+        // Glass, and forcing an opaque background fights the system — it suppressed the large
+        // navigation title on the Settings screen (a blank band where the title belongs) and cost
+        // scroll views the inset the floating tab bar needs, so the last row of Settings sat
+        // half-hidden behind the tab pill. Leave the new bars alone.
+        guard #unavailable(iOS 26) else { return }
+
         let appearance = UITabBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = UIColor(Theme.background)

--- a/apple/Akashic/Views/SettingsView.swift
+++ b/apple/Akashic/Views/SettingsView.swift
@@ -6,7 +6,7 @@ import UniformTypeIdentifiers
 ///   * **Consumer** (always visible): the honest sync status one-liner, a human storage summary,
 ///     the "Your name" field used for comments, an export reminder, "Replay intro", the
 ///     legal/support links, and the app version.
-///   * **Developer** (hidden): the migration workshop — active-store inspector, the T2.4 export
+///   * **Developer** (hidden): the migration workshop — active-store inspector, the T2.5 export
 ///     bundle importer, the T2.5 CloudKit importer, and the persistence-mode override. Nothing is
 ///     deleted; the runbook still needs these tools. The section is revealed by seven taps on the
 ///     version row (see `DeveloperTools`) and is always visible in DEBUG builds.
@@ -520,7 +520,7 @@ struct SettingsView: View {
                 }
             }
         } header: {
-            Text("Import from export bundle (T2.4)")
+            Text("Import from export bundle (T2.5)")
         } footer: {
             Text("The Simulator can read host paths directly. For results that persist across launches and show photos, switch the store to \(PersistenceMode.local.label) below, relaunch, then import. Re-importing preserves native edits — it only refreshes media paths and metadata.")
         }

--- a/apple/Akashic/Views/Theme.swift
+++ b/apple/Akashic/Views/Theme.swift
@@ -44,6 +44,44 @@ struct Card<Content: View>: View {
 }
 
 /// A small labelled stat pill (icon + value + caption).
+/// A row of `StatChip`s that wraps instead of squeezing.
+///
+/// Four chips side by side on a 402 pt phone leaves ~45 pt for the number, and `Formatters.meters`
+/// on a real summit is "5,895 m" — so Kilimanjaro's Summit chip rendered as "5,89…" even with
+/// `minimumScaleFactor`. Two columns on a compact width give every number its full width; a regular
+/// width (iPad, landscape) still gets the single row it has room for.
+struct StatChipRow: View {
+    struct Item: Identifiable {
+        var icon: String
+        var value: String
+        var caption: String
+        var id: String { caption }
+    }
+
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    let items: [Item]
+    var spacing: CGFloat = 10
+
+    /// Three or fewer chips already fit a phone row; only the four-chip case needs wrapping.
+    private var wraps: Bool { sizeClass == .compact && items.count > 3 }
+
+    var body: some View {
+        if wraps {
+            LazyVGrid(columns: [GridItem(spacing: spacing), GridItem(spacing: spacing)], spacing: spacing) {
+                ForEach(items) { chip in
+                    StatChip(icon: chip.icon, value: chip.value, caption: chip.caption)
+                }
+            }
+        } else {
+            HStack(spacing: spacing) {
+                ForEach(items) { chip in
+                    StatChip(icon: chip.icon, value: chip.value, caption: chip.caption)
+                }
+            }
+        }
+    }
+}
+
 struct StatChip: View {
     let icon: String
     let value: String

--- a/apple/Fixtures/recovered/mountKenya.json
+++ b/apple/Fixtures/recovered/mountKenya.json
@@ -6,8 +6,8 @@
     "description": "A spectacular traverse of Mount Kenya, ascending via the scenic Chogoria route past Lake Ellis and descending the Sirimon route. Includes a safari extension in the Masai Mara.",
     "heroImage": "/hero-images/mount-kenya-hero.png",
     "dates": {
-        "start": "2023-10-10",
-        "end": "2023-10-17"
+        "start": "2024-10-10",
+        "end": "2024-10-17"
     },
     "stats": {
         "totalDistance": 50,

--- a/apple/README.md
+++ b/apple/README.md
@@ -79,7 +79,8 @@ The app reads two launch environment variables (used for the screenshots in `Doc
 
 | Variable | Effect |
 |----------|--------|
-| `AKASHIC_TAB=0..3` | Select Journeys / Map / Stats / Settings |
+| `AKASHIC_TAB=0..2` | Select the tab: 0 Explore (globe) · 1 Stats · 2 Settings |
+| `AKASHIC_EMPTY=1` | Start with no journeys — the state a new customer sees on first launch |
 | `AKASHIC_OPEN=<slug or id>` | Open that journey's detail |
 | `AKASHIC_FORCE_LOCAL=1` | Force the on-disk `.local` store before the store is built |
 | `AKASHIC_IMPORT_ON_LAUNCH=1` | Run the export import at startup (see below) |


### PR DESCRIPTION
Found by walking the app in the simulator rather than reading it. None of these were visible to the 560-test suite, which is the point.

## The big one: empty journeys had no answer

A journey with no route and no days is legal (§4.1 keeps it legal because photos-only trips exist) and it is the state **every new customer is in for their first minutes**. The app's answer was silence: the globe flew into empty ocean, the detail screen showed a world-sized map thumbnail, four stat chips reading zero, "View all photos" for zero photos, and a bare "Days" heading over nothing.

Now: `JourneyNextStepsCard` offers three ways in (add a route — GPX or draw — add days, add photos), each opening a sheet that already existed. The globe says "Nothing to show yet" with an Open-journey button, through a detail sheet it previously had no route to at all. Shared-in journeys get the explanation without buttons that would fail.

This matters for the beta gate: ≥7 of 10 families completing a journey unaided.

## Also fixed

- **Kilimanjaro's Summit chip read "5,89…"** — four chips across a 402 pt phone leave ~45 pt for the number. `StatChipRow` wraps to two columns on compact widths, single row where there's room.
- **Settings opened with a blank band** where its large title belongs — the app forced an opaque background on the system bars, which fights iOS 26's Liquid Glass. Gated to `#unavailable(iOS 26)`.
- **Absent values were shown as zero**: "0 km / 0 m Summit" on a journey with no route now reads "—", matching the elevation-profile gate from the draw-on-map work.
- **State-aware route copy**: "Import route from GPX" until a route exists, "Replace" after; "Recompute stats" hidden when there's nothing to recompute.
- **The Mount Kenya fixture** carried dates a year off from its photos — corrected in CloudKit on 2026-07-22 but never in the bundled JSON, which matters because §4.2 plans to ship a fixture as demo content.
- Dev label said T2.4 for the T2.5 importer; the README listed four tabs when there are three.

## `AKASHIC_EMPTY=1`

The empty state could previously only be reached with a signed CloudKit build signed into an empty iCloud account — so the app's most important screen was the one its author could not look at, and could not screenshot for the store. One launch flag fixes both.

## Checked and deliberately not changed

- Content scrolling under the floating tab bar is correct iOS 26 behaviour; the last row clears the pill.
- Onboarding **does** warn about a missing iCloud account (`.noAccount` / `.restricted`). It stayed silent in my build because a non-CloudKit build cannot determine account status and deliberately doesn't cry wolf.
- The `+` button appearing to do nothing was my mis-tap, not a bug — the free-tier gate and paywall work correctly: with one owned journey, `+` presents the paywall with honest copy, restore, and legal links.

## Verification

560 tests green, all five configs build, and the whole flow driven by hand in the simulator with `AKASHIC_EMPTY=1`: fresh app → create → globe pill → Open journey → next steps → Add a route opens the Route block.

Still open (needs your click): the iPad layout check — the simulator asked for device access and didn't get it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)